### PR TITLE
build: reconcile Preview-1 daemon baseline (FrameworkReference + preview.3)

### DIFF
--- a/docs/plugin-developer-guide.md
+++ b/docs/plugin-developer-guide.md
@@ -4,7 +4,7 @@
 
 Plugin API 2.0 plugins reference only the SDK package:
 
-    <PackageReference Include="MCServerLauncher.Daemon.Plugin.Sdk" Version="2.0.0-preview.2" />
+    <PackageReference Include="MCServerLauncher.Daemon.Plugin.Sdk" Version="2.0.0-preview.3" />
 
 The SDK carries the exact Daemon API/Common dependency chain, the source generator, and
 the buildTransitive publish targets. Do not add a direct Daemon API package reference.

--- a/docs/preview1-package-pin.md
+++ b/docs/preview1-package-pin.md
@@ -1,12 +1,38 @@
 # Preview-1 Package Pin
 
-Status: accepted for MCP-0..5.
-Branch: `feat/plugin-sdk-2-preview1`
-Release: `2.0.0-preview.2` ([GitHub Release](https://github.com/MCSLTeam/MCServerLauncher-Future/releases/tag/2.0.0-preview.2))
-Source commit: `a5510a6089a88692ff7ff0cde7fd0b6249a3b965`
+Status: internal baseline `2.0.0-preview.3` (2026-07-25) for MCP-0..5.
+No public release exists or is planned for Preview-1 packages; SDK-9a public
+distribution stays an explicitly reopened gate. The `2.0.0-preview.2`
+acceptance record below is historical.
 Decision source: `docs/superpowers/specs/2026-07-20-plugin-sdk-mcp-decisions.md`, sections 1, 10, and 12.
 
-## Gate status
+## Internal `2.0.0-preview.3` baseline (2026-07-25)
+
+- Source: branch `codex/preview1-baseline-reconcile` — `origin/master`
+  (`8f2796f7`, carries `fix(daemon): preserve buffered ready lifecycle
+  signals`) plus the cherry-picked `build(daemon): declare ASP.NET Core
+  framework for plugins` change. This is the first commit line that satisfies
+  both Preview-1 daemon requirements (spec section 6 lifecycle correctness and
+  spec section 8 `Microsoft.AspNetCore.App` FrameworkReference) at once.
+- Version advanced to `2.0.0-preview.3` because two payload-identical but
+  bitwise-different `2.0.0-preview.2` builds already circulated (the
+  Action-built set from `a5510a60` and the locally built set from `4f3f1d8c`),
+  and same-version/different-hash packages break locked restores that mix
+  caches (NU1403). The reconciled commit would have added a third.
+- Packages are produced locally or in CI from the pinned commit via the MCP
+  repo's `tools/Get-SdkPackages.ps1`; the exact pinned commit is recorded
+  there and in the MCP repo's `.github/workflows/ci.yml` plus its lockfiles.
+- No GitHub Release, tag, or nuget.org publication is planned for
+  `2.0.0-preview.2` or `2.0.0-preview.3`.
+
+## Historical record: `2.0.0-preview.2` acceptance (superseded)
+
+Branch: `feat/plugin-sdk-2-preview1`
+Release workflow tag: `2.0.0-preview.2` (assets slated for removal; no
+publication plan)
+Source commit: `a5510a6089a88692ff7ff0cde7fd0b6249a3b965`
+
+### Gate status
 
 The accepted packages were downloaded from the public prerelease above after
 Release workflow run `30101725253` completed successfully. A second independent
@@ -17,7 +43,7 @@ and the published Release daemon fixture also passed. The latter ran all three
 PluginIntegrationTests with `MCSL_PLUGIN_PACKAGE_SOURCE` bound to the downloaded
 Release packages.
 
-## Exact versions
+### Exact versions
 
 | Package id | Version |
 |---|---|
@@ -28,7 +54,7 @@ Release packages.
 MCP and external consumers MUST pin exact versions, without floating ranges,
 and should use a lockfile.
 
-## Dependency pins in packages
+### Dependency pins in packages
 
 - `MCServerLauncher.Daemon.API` -> `MCServerLauncher.Common = [2.0.0-preview.2]`
 - `MCServerLauncher.Daemon.Plugin.Sdk` -> `MCServerLauncher.Daemon.API = [2.0.0-preview.2]`
@@ -37,7 +63,7 @@ and should use a lockfile.
 - `MCServerLauncher.Daemon.Plugin.Sdk` carries `buildTransitive` props and
   targets for `mcsl-plugin.json` and `MCSLPluginBundle`.
 
-## Content fingerprints
+### Content fingerprints
 
 Whole-nupkg SHA-256 is not the acceptance pin: NuGet embeds repository and
 timestamp metadata that can change across repacks while payload code remains
@@ -77,13 +103,13 @@ dotnet pack src/MCServerLauncher.Daemon.Plugin.Sdk/MCServerLauncher.Daemon.Plugi
 The release workflow recognizes the `2.0.0-preview.2` tag, packs all three
 declared versions with `MCSL_PIN_PACKAGE_PAYLOAD=true`, and attaches each nupkg.
 
-### `MCServerLauncher.Common.2.0.0-preview.2.nupkg`
+#### `MCServerLauncher.Common.2.0.0-preview.2.nupkg`
 
 | Entry | SHA-256 |
 |---|---|
 | `lib/net10.0/MCServerLauncher.Common.dll` | `4d44f9993d9def979db6e80c7004c4d2ddf8fa92cdaf5511dc69842ad6dae38c` |
 
-### `MCServerLauncher.Daemon.API.2.0.0-preview.2.nupkg`
+#### `MCServerLauncher.Daemon.API.2.0.0-preview.2.nupkg`
 
 | Entry | SHA-256 |
 |---|---|
@@ -96,7 +122,7 @@ Nuspec dependencies are exact:
 - `RustyOptions = [0.10.1]`
 - `Microsoft.Extensions.Logging.Abstractions = [10.0.9]`
 
-### `MCServerLauncher.Daemon.Plugin.Sdk.2.0.0-preview.2.nupkg`
+#### `MCServerLauncher.Daemon.Plugin.Sdk.2.0.0-preview.2.nupkg`
 
 | Entry | SHA-256 |
 |---|---|
@@ -132,7 +158,7 @@ atomic admission skip.
 ## Consumer pin
 
 ```xml
-<PackageReference Include="MCServerLauncher.Daemon.Plugin.Sdk" Version="2.0.0-preview.2" />
+<PackageReference Include="MCServerLauncher.Daemon.Plugin.Sdk" Version="2.0.0-preview.3" />
 ```
 
 Local-feed restore requires the three nupkgs above and nuget.org for transitive
@@ -152,5 +178,7 @@ and the published-host suite with `MCSL_PUBLISHED_DAEMON` pointing to the
 downloaded daemon asset and `MCSL_PLUGIN_PACKAGE_SOURCE` pointing to the three
 downloaded nupkgs.
 
-Distribution remains GitHub Release assets for all three nupkgs. Public
-nuget.org publication is not required for the first accepted pin.
+Distribution is internal-only: consumers restore the three nupkgs from a local
+feed built by the MCP repo's `tools/Get-SdkPackages.ps1` at the pinned commit.
+Public distribution (GitHub Release assets or nuget.org) requires explicitly
+reopening SDK-9a.

--- a/src/MCServerLauncher.Common/MCServerLauncher.Common.csproj
+++ b/src/MCServerLauncher.Common/MCServerLauncher.Common.csproj
@@ -8,7 +8,7 @@
         <LangVersion>14</LangVersion>
         <IsPackable>true</IsPackable>
         <PackageId>MCServerLauncher.Common</PackageId>
-        <PackageVersion>2.0.0-preview.2</PackageVersion>
+        <PackageVersion>2.0.0-preview.3</PackageVersion>
         <Authors>MCSLTeam</Authors>
         <Description>Shared wire contracts and serialization models for MCServerLauncher Future.</Description>
         <PackageLicenseExpression>GPL-3.0-only</PackageLicenseExpression>

--- a/src/MCServerLauncher.Daemon.API/MCServerLauncher.Daemon.API.csproj
+++ b/src/MCServerLauncher.Daemon.API/MCServerLauncher.Daemon.API.csproj
@@ -7,7 +7,7 @@
     <LangVersion>14</LangVersion>
     <IsPackable>true</IsPackable>
     <PackageId>MCServerLauncher.Daemon.API</PackageId>
-    <PackageVersion>2.0.0-preview.2</PackageVersion>
+    <PackageVersion>2.0.0-preview.3</PackageVersion>
     <Authors>MCSLTeam</Authors>
     <Description>Transport-neutral application and startup-plugin contracts for MCServerLauncher Future.</Description>
     <PackageLicenseExpression>GPL-3.0-only</PackageLicenseExpression>

--- a/src/MCServerLauncher.Daemon.Plugin.Sdk/MCServerLauncher.Daemon.Plugin.Sdk.csproj
+++ b/src/MCServerLauncher.Daemon.Plugin.Sdk/MCServerLauncher.Daemon.Plugin.Sdk.csproj
@@ -7,7 +7,7 @@
     <LangVersion>14</LangVersion>
     <IsPackable>true</IsPackable>
     <PackageId>MCServerLauncher.Daemon.Plugin.Sdk</PackageId>
-    <PackageVersion>2.0.0-preview.2</PackageVersion>
+    <PackageVersion>2.0.0-preview.3</PackageVersion>
     <Authors>MCSLTeam</Authors>
     <Description>
       Developer SDK for MCServerLauncher Future plugins: feature-gated source generation,

--- a/src/MCServerLauncher.Daemon.Plugin.Sdk/README.md
+++ b/src/MCServerLauncher.Daemon.Plugin.Sdk/README.md
@@ -5,7 +5,7 @@ Developer SDK for MCServerLauncher Future plugins.
 ## Install
 
 ```xml
-<PackageReference Include="MCServerLauncher.Daemon.Plugin.Sdk" Version="2.0.0-preview.2" />
+<PackageReference Include="MCServerLauncher.Daemon.Plugin.Sdk" Version="2.0.0-preview.3" />
 ```
 
 Place `mcsl-plugin.json` beside the project (or under the project directory) and mark a partial class with `[DaemonPluginModule]`.

--- a/src/MCServerLauncher.Daemon/MCServerLauncher.Daemon.csproj
+++ b/src/MCServerLauncher.Daemon/MCServerLauncher.Daemon.csproj
@@ -80,10 +80,12 @@
     </ItemGroup>
 
     <ItemGroup>
+        <!-- Required by plugins that host private ASP.NET Core applications. The plugin owns
+             its Kestrel instance, DI provider, and lifecycle; the runtime framework must be
+             declared by the process per the supported .NET plugin loading model. -->
+        <FrameworkReference Include="Microsoft.AspNetCore.App" />
         <PackageReference Include="Brigadier.NET" Version="1.2.13" />
         <PackageReference Include="Downloader" Version="3.1.2" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.4" />
-        <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="10.0.0" />
         <PackageReference Include="Microsoft.Management.Infrastructure" Version="3.0.0" />
         <PackageReference Include="RustyOptions" Version="0.10.1" />
         <PackageReference Include="Serilog" Version="4.3.0" />
@@ -91,7 +93,6 @@
         <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
         <PackageReference Include="Serilog.Sinks.File" Version="6.0.0" />
         <PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.2" />
         <PackageReference Include="MessagePipe" Version="1.8.2" />
         <PackageReference Include="NuGet.Versioning" Version="7.6.0" />
         <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.9.0" />

--- a/tests/Fixtures/Plugins/PackageReferenceConsumer/PackageReferenceConsumer.csproj
+++ b/tests/Fixtures/Plugins/PackageReferenceConsumer/PackageReferenceConsumer.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MCServerLauncher.Daemon.Plugin.Sdk" Version="2.0.0-preview.2" />
+    <PackageReference Include="MCServerLauncher.Daemon.Plugin.Sdk" Version="2.0.0-preview.3" />
   </ItemGroup>
 
 </Project>

--- a/tests/MCServerLauncher.Daemon.ApiTests/PackageContractTests.cs
+++ b/tests/MCServerLauncher.Daemon.ApiTests/PackageContractTests.cs
@@ -11,28 +11,28 @@ public sealed class PackageContractTests
     private static readonly PinnedPayload[] PinnedPayloads =
     [
         new(
-            "MCServerLauncher.Common.2.0.0-preview.2.nupkg",
+            "MCServerLauncher.Common.2.0.0-preview.3.nupkg",
             "lib/net10.0/MCServerLauncher.Common.dll"),
         new(
-            "MCServerLauncher.Daemon.API.2.0.0-preview.2.nupkg",
+            "MCServerLauncher.Daemon.API.2.0.0-preview.3.nupkg",
             "lib/net10.0/MCServerLauncher.Daemon.API.dll"),
         new(
-            "MCServerLauncher.Daemon.API.2.0.0-preview.2.nupkg",
+            "MCServerLauncher.Daemon.API.2.0.0-preview.3.nupkg",
             "buildTransitive/MCServerLauncher.Daemon.API.targets"),
         new(
-            "MCServerLauncher.Daemon.Plugin.Sdk.2.0.0-preview.2.nupkg",
+            "MCServerLauncher.Daemon.Plugin.Sdk.2.0.0-preview.3.nupkg",
             "lib/net10.0/MCServerLauncher.Daemon.Plugin.Sdk.dll"),
         new(
-            "MCServerLauncher.Daemon.Plugin.Sdk.2.0.0-preview.2.nupkg",
+            "MCServerLauncher.Daemon.Plugin.Sdk.2.0.0-preview.3.nupkg",
             "analyzers/dotnet/cs/MCServerLauncher.Daemon.Plugin.Generators.dll"),
         new(
-            "MCServerLauncher.Daemon.Plugin.Sdk.2.0.0-preview.2.nupkg",
+            "MCServerLauncher.Daemon.Plugin.Sdk.2.0.0-preview.3.nupkg",
             "analyzers/dotnet/cs/NuGet.Versioning.dll"),
         new(
-            "MCServerLauncher.Daemon.Plugin.Sdk.2.0.0-preview.2.nupkg",
+            "MCServerLauncher.Daemon.Plugin.Sdk.2.0.0-preview.3.nupkg",
             "buildTransitive/MCServerLauncher.Daemon.Plugin.Sdk.props"),
         new(
-            "MCServerLauncher.Daemon.Plugin.Sdk.2.0.0-preview.2.nupkg",
+            "MCServerLauncher.Daemon.Plugin.Sdk.2.0.0-preview.3.nupkg",
             "buildTransitive/MCServerLauncher.Daemon.Plugin.Sdk.targets")
     ];
 
@@ -80,7 +80,7 @@ public sealed class PackageContractTests
                     StringComparer.Ordinal);
 
             Assert.Equal(3, dependencies.Count);
-            Assert.Equal("[2.0.0-preview.2]", dependencies["MCServerLauncher.Common"]);
+            Assert.Equal("[2.0.0-preview.3]", dependencies["MCServerLauncher.Common"]);
             Assert.Equal("[0.10.1]", dependencies["RustyOptions"]);
             Assert.Equal("[10.0.9]", dependencies["Microsoft.Extensions.Logging.Abstractions"]);
             Assert.Contains(package.Entries, entry => entry.FullName == "lib/net10.0/MCServerLauncher.Daemon.API.dll");
@@ -141,7 +141,7 @@ public sealed class PackageContractTests
             var metadata = nuspec.Descendants(ns + "metadata").Single();
 
             Assert.Equal("MCServerLauncher.Common", (string?)metadata.Element(ns + "id"));
-            Assert.Equal("2.0.0-preview.2", (string?)metadata.Element(ns + "version"));
+            Assert.Equal("2.0.0-preview.3", (string?)metadata.Element(ns + "version"));
             Assert.Equal("MCSLTeam", (string?)metadata.Element(ns + "authors"));
             Assert.Equal("https://github.com/MCSLTeam/MCServerLauncher-Future", (string?)metadata.Element(ns + "projectUrl"));
             Assert.Equal("GPL-3.0-only", metadata.Element(ns + "license")?.Value);
@@ -200,12 +200,12 @@ public sealed class PackageContractTests
                     StringComparer.Ordinal);
 
             Assert.Equal(2, dependencies.Count);
-            Assert.Equal("[2.0.0-preview.2]", dependencies["MCServerLauncher.Daemon.API"]);
+            Assert.Equal("[2.0.0-preview.3]", dependencies["MCServerLauncher.Daemon.API"]);
             Assert.Equal("[10.0.9]", dependencies["Microsoft.Extensions.DependencyInjection"]);
 
             var metadata = nuspec.Descendants(ns + "metadata").Single();
             Assert.Equal("MCServerLauncher.Daemon.Plugin.Sdk", (string?)metadata.Element(ns + "id"));
-            Assert.Equal("2.0.0-preview.2", (string?)metadata.Element(ns + "version"));
+            Assert.Equal("2.0.0-preview.3", (string?)metadata.Element(ns + "version"));
             Assert.Contains(package.Entries, entry => entry.FullName == "lib/net10.0/MCServerLauncher.Daemon.Plugin.Sdk.dll");
             Assert.Contains(package.Entries, entry => entry.FullName == "README.md");
             Assert.Contains(package.Entries, entry => entry.FullName == "buildTransitive/MCServerLauncher.Daemon.Plugin.Sdk.props");
@@ -353,7 +353,7 @@ public sealed class PackageContractTests
             "MCServerLauncher.Daemon.Plugin.Generators",
             "Release",
             "netstandard2.0");
-        var packagePath = Path.Combine(packageOutput, "MCServerLauncher.Daemon.Plugin.Sdk.2.0.0-preview.2.nupkg");
+        var packagePath = Path.Combine(packageOutput, "MCServerLauncher.Daemon.Plugin.Sdk.2.0.0-preview.3.nupkg");
         using var package = ZipFile.OpenRead(packagePath);
 
         AssertPackageEntryMatchesFile(

--- a/tests/MCServerLauncher.PluginIntegrationTests/PublishedInstanceHealthPluginTests.cs
+++ b/tests/MCServerLauncher.PluginIntegrationTests/PublishedInstanceHealthPluginTests.cs
@@ -553,9 +553,9 @@ public sealed class PublishedInstanceHealthPluginTests
             {
                 var requiredPackages = new[]
                 {
-                    "MCServerLauncher.Common.2.0.0-preview.2.nupkg",
-                    "MCServerLauncher.Daemon.API.2.0.0-preview.2.nupkg",
-                    "MCServerLauncher.Daemon.Plugin.Sdk.2.0.0-preview.2.nupkg"
+                    "MCServerLauncher.Common.2.0.0-preview.3.nupkg",
+                    "MCServerLauncher.Daemon.API.2.0.0-preview.3.nupkg",
+                    "MCServerLauncher.Daemon.Plugin.Sdk.2.0.0-preview.3.nupkg"
                 };
                 foreach (var packageName in requiredPackages)
                 {


### PR DESCRIPTION
## Summary

- Cherry-pick `build(daemon): declare ASP.NET Core framework for plugins` onto master so a single commit line carries both Preview-1 daemon requirements: the merged lifecycle fix (`fix(daemon): preserve buffered ready lifecycle signals`, spec section 6) and the `Microsoft.AspNetCore.App` FrameworkReference (spec section 8). Before this PR, master-built daemons could not host plugin-private ASP.NET Core applications, and the MCP-pinned branch commit lacked the lifecycle fix.
- Advance the internal package baseline to `2.0.0-preview.3`: two payload-identical but bitwise-different `2.0.0-preview.2` builds already circulated (Action-built from `a5510a60`, locally built from `4f3f1d8c`), and same-version/different-hash packages break locked restores that mix caches (NU1403). No release or publication is planned for either version.
- Update `docs/preview1-package-pin.md` to internal-only status; the preview.2 acceptance record is retained as history.

## Verification

- `dotnet test tests/MCServerLauncher.ProtocolTests` full suite: 1180/1180 (one timing-sensitive flake per earlier full-suite run — different test each time, both passed focused reruns and a clean third full run; matches the flake pattern already recorded in the execution handoff).
- `dotnet test tests/MCServerLauncher.Daemon.ApiTests`: 115/115 including PackageContract tests re-pinned to preview.3.
- `git diff --check` clean.

The MCP repo re-pins to this branch head for its local package baseline.