### PR TITLE
fix(plugins): require explicit entries opt-in for admission

### DIFF
--- a/docs/daemon-manual.md
+++ b/docs/daemon-manual.md
@@ -32,6 +32,8 @@ dotnet publish src/MCServerLauncher.Daemon/MCServerLauncher.Daemon.csproj `
 
 Place each plugin bundle under `artifacts/publish/daemon/plugins/<plugin-id>/`. A bundle contains `mcsl-plugin.json`, the entry assembly, and private implementation dependencies. Shared `MCServerLauncher.Daemon.API.dll` and `MCServerLauncher.Common.dll` copies are rejected.
 
+A bundle loads only when the daemon `config.json` opts it in explicitly: `plugins.entries.<plugin-id>.enabled` must be `true`. A plugin id absent from `plugins.entries` is disabled. Required features must additionally fall within the effective grant set (`grant_level` plus `plugins.plugin_grants.<plugin-id>`); features above the grant level need an interactive approval or a recorded `plugins.admissions` decision.
+
 ## Startup and shutdown
 
 Plugins are discovered, validated, configured, started, admitted to the frozen catalog, and activated before the first client connection is accepted. A failed plugin is logged and skipped without preventing daemon startup. Shutdown cancels plugin lifetimes, stops successful plugins in reverse start order, closes event/RPC ownership, and then stops the daemon services.

--- a/docs/plugin-developer-guide.md
+++ b/docs/plugin-developer-guide.md
@@ -114,7 +114,9 @@ cancels the lifetime token first and stops successful plugins in reverse order.
 
 MCSLPluginBundle=true removes host-provided shared assemblies from the bundle. Deploy the
 published entry DLL, mcsl-plugin.json, optional config.json, and private dependencies
-under plugins/community.example.health/ beside the daemon. Do not bundle the daemon,
+under plugins/community.example.health/ beside the daemon. The operator must then opt the
+plugin in through the daemon config.json (`plugins.entries.community.example.health.enabled: true`);
+a plugin id absent from `plugins.entries` stays disabled. Do not bundle the daemon,
 TouchSocket, MessagePipe, Serilog, MCServerLauncher.Daemon.API.dll,
 MCServerLauncher.Common.dll, or MCServerLauncher.Daemon.Plugin.Sdk.dll.
 

--- a/src/MCServerLauncher.Daemon/Plugins/Configuration/PluginAdmissionPolicy.cs
+++ b/src/MCServerLauncher.Daemon/Plugins/Configuration/PluginAdmissionPolicy.cs
@@ -109,7 +109,9 @@ internal static class PluginAdmissionPolicy
                 denied.Add(required);
         }
 
-        var enabled = !config.Entries.TryGetValue(manifest.Identity.Id, out var entry) || entry.Enabled;
+        // Spec section 4: a plugin id absent from entries is disabled. Loading requires an
+        // explicit entries record (explicit opt-in); the absence default is false.
+        var enabled = config.Entries.TryGetValue(manifest.Identity.Id, out var entry) && entry.Enabled;
 
         return new PluginFeatureGrant(manifest.Identity.Id, granted.ToImmutable(), denied.ToImmutable(), enabled);
     }

--- a/tests/MCServerLauncher.PluginIntegrationTests/PublishedInstanceHealthPluginTests.cs
+++ b/tests/MCServerLauncher.PluginIntegrationTests/PublishedInstanceHealthPluginTests.cs
@@ -223,9 +223,25 @@ public sealed class PublishedInstanceHealthPluginTests
             var daemonPath = Path.Combine(root, Path.GetFileName(source));
             var port = GetUnusedLoopbackPort();
             var token = Convert.ToHexString(Guid.NewGuid().ToByteArray()).ToLowerInvariant();
-            var pluginsConfig = includeNeverCompletingDisposePlugin
-                ? ",\"plugins\":{\"grant_level\":\"High\",\"plugin_grants\":{\"fixture.late-http-cleanup\":[\"network.http.listen\"]}}"
+            // Spec section 4: plugins load only with an explicit entries opt-in record.
+            var entryIds = new List<string>
+            {
+                "community.instance-health",
+                "fixture.returned-error",
+                "fixture.throwing",
+                "fixture.start-returned-error",
+                "fixture.start-throwing",
+                "fixture.package-reference-consumer",
+            };
+            if (includeNeverCompletingStartPlugin)
+                entryIds.Add("fixture.start-never-completes");
+            if (includeNeverCompletingDisposePlugin)
+                entryIds.Add("fixture.late-http-cleanup");
+            var entriesJson = string.Join(",", entryIds.Select(id => $"\"{id}\":{{\"enabled\":true}}"));
+            var pluginGrantsJson = includeNeverCompletingDisposePlugin
+                ? "\"grant_level\":\"High\",\"plugin_grants\":{\"fixture.late-http-cleanup\":[\"network.http.listen\"]},"
                 : string.Empty;
+            var pluginsConfig = $",\"plugins\":{{{pluginGrantsJson}\"entries\":{{{entriesJson}}}}}";
             await File.WriteAllTextAsync(
                 Path.Combine(root, "config.json"),
                 $$"""{"port":{{port}},"secret":"{{token}}","main_token":"{{token}}","file_download_sessions":1,"verbose":false{{pluginsConfig}}}""");

--- a/tests/MCServerLauncher.ProtocolTests/Configuration/TouchSocketV2RealHostIntegrationTests.cs
+++ b/tests/MCServerLauncher.ProtocolTests/Configuration/TouchSocketV2RealHostIntegrationTests.cs
@@ -144,12 +144,20 @@ public sealed class TouchSocketV2RealHostIntegrationTests
             "Sec-WebSocket-Key",
             Convert.ToBase64String(Guid.NewGuid().ToByteArray()));
         using var timeout = new CancellationTokenSource(Timeout);
-        using var response = await client.SendAsync(
-            request,
-            HttpCompletionOption.ResponseHeadersRead,
-            timeout.Token);
+        try
+        {
+            using var response = await client.SendAsync(
+                request,
+                HttpCompletionOption.ResponseHeadersRead,
+                timeout.Token);
 
-        Assert.NotEqual(System.Net.HttpStatusCode.SwitchingProtocols, response.StatusCode);
+            Assert.NotEqual(System.Net.HttpStatusCode.SwitchingProtocols, response.StatusCode);
+        }
+        catch (HttpRequestException exception) when (HasConnectionReset(exception))
+        {
+            // The host may refuse the invalid upgrade by resetting the connection instead
+            // of answering with an HTTP status; a reset connection was equally not upgraded.
+        }
     }
 
     private static async Task AssertHttpMetadataReportsV2Async(int port)

--- a/tests/MCServerLauncher.ProtocolTests/Plugins/PluginAdmissionPolicyTests.cs
+++ b/tests/MCServerLauncher.ProtocolTests/Plugins/PluginAdmissionPolicyTests.cs
@@ -77,7 +77,7 @@ public sealed class PluginAdmissionPolicyTests
     public void DecideGrantsAllRequiredWhenWithinCeiling()
     {
         var manifest = Manifest("mcp", [PluginFeature.InstanceQuery, PluginFeature.RpcRegister]);
-        var grant = PluginAdmissionPolicy.Decide(manifest, DaemonPluginsConfig.Default);
+        var grant = PluginAdmissionPolicy.Decide(manifest, EnabledConfig());
 
         Assert.True(grant.Enabled);
         Assert.Empty(grant.Denied);
@@ -89,7 +89,7 @@ public sealed class PluginAdmissionPolicyTests
     {
         // network.http.listen is High risk; Medium ceiling denies it without plugin_grants.
         var manifest = Manifest("mcp", [PluginFeature.InstanceQuery, PluginFeature.NetworkHttpListen]);
-        var grant = PluginAdmissionPolicy.Decide(manifest, DaemonPluginsConfig.Default);
+        var grant = PluginAdmissionPolicy.Decide(manifest, EnabledConfig());
 
         Assert.True(grant.Enabled);
         var denied = Assert.Single(grant.Denied);
@@ -104,6 +104,7 @@ public sealed class PluginAdmissionPolicyTests
         {
             GrantLevel = "Medium",
             PluginGrants = { ["mcp"] = ["network.http.listen"] },
+            Entries = { ["mcp"] = new PluginEntryConfig() },
         };
         // Even though the feature is granted by plugin_grants, Decide checks membership of the
         // effective set, not IsImplemented. Admission of unimplemented features is handled earlier
@@ -128,6 +129,29 @@ public sealed class PluginAdmissionPolicyTests
         var grant = PluginAdmissionPolicy.Decide(manifest, config);
 
         Assert.False(grant.Enabled);
+    }
+
+    [Fact]
+    public void AbsentEntryDisablesPlugin()
+    {
+        // Spec section 4: a plugin id absent from entries is disabled (explicit opt-in).
+        var manifest = Manifest("mcp", [PluginFeature.InstanceQuery]);
+        var grant = PluginAdmissionPolicy.Decide(manifest, DaemonPluginsConfig.Default);
+
+        Assert.False(grant.Enabled);
+    }
+
+    [Fact]
+    public void PreflightSkipsPluginAbsentFromEntries()
+    {
+        var console = new FakePreflightConsole(isInteractive: true, PluginPreflightDecision.Approve);
+        var preflight = new PluginAdmissionPreflight(DaemonPluginsConfig.Default, console);
+
+        var outcome = preflight.Evaluate(Manifest("mcp", [PluginFeature.InstanceQuery]));
+
+        Assert.False(outcome.IsAdmitted);
+        Assert.Equal("entry_disabled", outcome.Code);
+        Assert.Equal(0, console.PromptCount);
     }
 
     [Fact]
@@ -173,7 +197,7 @@ public sealed class PluginAdmissionPolicyTests
     public void PreflightSilentlyAdmitsFeaturesWithinCeiling()
     {
         var console = new FakePreflightConsole(isInteractive: true, PluginPreflightDecision.Deny);
-        var preflight = new PluginAdmissionPreflight(DaemonPluginsConfig.Default, console);
+        var preflight = new PluginAdmissionPreflight(EnabledConfig(), console);
 
         var outcome = preflight.Evaluate(Manifest("mcp", [PluginFeature.InstanceQuery]));
 
@@ -194,7 +218,7 @@ public sealed class PluginAdmissionPolicyTests
     {
         var console = new FakePreflightConsole(isInteractive: true, (PluginPreflightDecision)decisionValue);
         var store = new FakeAdmissionStore(succeeds: true);
-        var preflight = new PluginAdmissionPreflight(DaemonPluginsConfig.Default, console, store);
+        var preflight = new PluginAdmissionPreflight(EnabledConfig(), console, store);
 
         var outcome = preflight.Evaluate(Manifest("mcp", [PluginFeature.NetworkHttpListen]));
 
@@ -208,7 +232,7 @@ public sealed class PluginAdmissionPolicyTests
     public void NonInteractivePreflightSkipsFeaturesOutsideCeiling()
     {
         var console = new FakePreflightConsole(isInteractive: false, PluginPreflightDecision.Approve);
-        var preflight = new PluginAdmissionPreflight(DaemonPluginsConfig.Default, console);
+        var preflight = new PluginAdmissionPreflight(EnabledConfig(), console);
 
         var outcome = preflight.Evaluate(Manifest("mcp", [PluginFeature.NetworkHttpListen]));
 
@@ -224,6 +248,7 @@ public sealed class PluginAdmissionPolicyTests
         var config = new DaemonPluginsConfig
         {
             PluginGrants = { ["mcp"] = ["network.http.listen"] },
+            Entries = { ["mcp"] = new PluginEntryConfig() },
             Admissions =
             {
                 ["mcp"] = new PluginAdmissionConfig
@@ -257,6 +282,7 @@ public sealed class PluginAdmissionPolicyTests
         var config = new DaemonPluginsConfig
         {
             PluginGrants = { ["mcp"] = ["network.http.listen"] },
+            Entries = { ["mcp"] = new PluginEntryConfig() },
             Admissions =
             {
                 ["mcp"] = new PluginAdmissionConfig
@@ -285,6 +311,7 @@ public sealed class PluginAdmissionPolicyTests
         var manifest = Manifest("mcp", [PluginFeature.InstanceQuery], "digest-current");
         var config = new DaemonPluginsConfig
         {
+            Entries = { ["mcp"] = new PluginEntryConfig() },
             Admissions =
             {
                 ["mcp"] = new PluginAdmissionConfig
@@ -310,7 +337,7 @@ public sealed class PluginAdmissionPolicyTests
     {
         var console = new FakePreflightConsole(isInteractive: true, PluginPreflightDecision.ApprovePermanent);
         var store = new FakeAdmissionStore(succeeds: false);
-        var preflight = new PluginAdmissionPreflight(DaemonPluginsConfig.Default, console, store);
+        var preflight = new PluginAdmissionPreflight(EnabledConfig(), console, store);
 
         var outcome = preflight.Evaluate(Manifest("mcp", [PluginFeature.NetworkHttpListen]));
 
@@ -428,6 +455,13 @@ public sealed class PluginAdmissionPolicyTests
         Assert.True(registry.TryRegister("other", mappedIpv4, out _));
         Assert.False(registry.TryRegister("other", ipv6, out var ipv6Conflict));
         Assert.Equal("ipv6", ipv6Conflict);
+    }
+
+    private static DaemonPluginsConfig EnabledConfig(string id = "mcp")
+    {
+        var config = new DaemonPluginsConfig();
+        config.Entries[id] = new PluginEntryConfig();
+        return config;
     }
 
     private static PluginManifest Manifest(

--- a/tests/MCServerLauncher.ProtocolTests/Plugins/PluginHostLifecycleTests.cs
+++ b/tests/MCServerLauncher.ProtocolTests/Plugins/PluginHostLifecycleTests.cs
@@ -62,7 +62,9 @@ public sealed class PluginHostLifecycleTests
             logger,
             fixture.PluginsRoot,
             new PluginEventBus(provider.GetRequiredService<EventFactory>()),
-            TimeSpan.FromMilliseconds(250));
+            TimeSpan.FromMilliseconds(250),
+            fixture.CreateConfig("Medium"),
+            new PluginHttpEndpointRegistry());
 
         // Allow scheduler contention from the full protocol suite while still bounding an
         // otherwise unbounded startup. The fixture includes permanently incomplete starts.
@@ -142,7 +144,9 @@ public sealed class PluginHostLifecycleTests
                 logger,
                 fixture.PluginsRoot,
                 new PluginEventBus(provider.GetRequiredService<EventFactory>()),
-                TimeSpan.FromMilliseconds(150));
+                TimeSpan.FromMilliseconds(150),
+                fixture.CreateConfig("Medium"),
+                new PluginHttpEndpointRegistry());
 
             var startedAt = Stopwatch.GetTimestamp();
             await host.StartAsync(CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(2));
@@ -211,7 +215,10 @@ public sealed class PluginHostLifecycleTests
             loggerFactory,
             logger,
             fixture.PluginsRoot,
-            new PluginEventBus(provider.GetRequiredService<EventFactory>()));
+            new PluginEventBus(provider.GetRequiredService<EventFactory>()),
+            TimeSpan.FromSeconds(30),
+            fixture.CreateConfig("Medium"),
+            new PluginHttpEndpointRegistry());
 
         await host.StartAsync(CancellationToken.None);
         Assert.Contains(logger.Messages, message =>
@@ -348,7 +355,8 @@ public sealed class PluginHostLifecycleTests
         var logger = new RecordingLogger<PluginHost>();
         var console = new RecordingPreflightConsole(PluginPreflightDecision.ApprovePermanent);
         var store = new RecordingAdmissionStore();
-        var preflight = new PluginAdmissionPreflight(DaemonPluginsConfig.Default, console, store);
+        var metadataMismatchConfig = fixture.CreateConfig("Medium");
+        var preflight = new PluginAdmissionPreflight(metadataMismatchConfig, console, store);
         var services = new ServiceCollection();
         services.AddMessagePipe(options =>
         {
@@ -365,7 +373,7 @@ public sealed class PluginHostLifecycleTests
             fixture.PluginsRoot,
             new PluginEventBus(provider.GetRequiredService<EventFactory>()),
             TimeSpan.FromSeconds(1),
-            DaemonPluginsConfig.Default,
+            metadataMismatchConfig,
             new PluginHttpEndpointRegistry(),
             preflight: preflight);
 
@@ -443,7 +451,7 @@ public sealed class PluginHostLifecycleTests
                 fixture.PluginsRoot,
                 new PluginEventBus(provider.GetRequiredService<EventFactory>()),
                 TimeSpan.FromSeconds(1),
-                DaemonPluginsConfig.Default,
+                fixture.CreateConfig("Medium"),
                 new PluginHttpEndpointRegistry(),
                 instanceApplication: rawApplication,
                 operationApplication: rawOperations);
@@ -558,7 +566,7 @@ public sealed class PluginHostLifecycleTests
                 options.EnableCaptureStackTrace = false;
             });
             using var provider = services.BuildServiceProvider();
-            var config = DaemonPluginsConfig.Default;
+            var config = fixture.CreateConfig("Medium");
             var host = new PluginHost(
                 new SnapshotSource(new InstanceCatalogSnapshot([])),
                 new RecordingLoggerFactory(logger),
@@ -633,7 +641,7 @@ public sealed class PluginHostLifecycleTests
                 options.EnableCaptureStackTrace = false;
             });
             using var provider = services.BuildServiceProvider();
-            var config = new DaemonPluginsConfig { GrantLevel = "High" };
+            var config = fixture.CreateConfig();
             var endpoints = new PluginHttpEndpointRegistry();
             var host = new PluginHost(
                 new SnapshotSource(new InstanceCatalogSnapshot([])),
@@ -753,7 +761,7 @@ public sealed class PluginHostLifecycleTests
                 options.EnableCaptureStackTrace = false;
             });
             using var provider = services.BuildServiceProvider();
-            var config = new DaemonPluginsConfig { GrantLevel = "High" };
+            var config = fixture.CreateConfig();
             var endpoints = new PluginHttpEndpointRegistry();
             var host = new PluginHost(
                 new SnapshotSource(new InstanceCatalogSnapshot([])),
@@ -894,7 +902,7 @@ public sealed class PluginHostLifecycleTests
                 options.EnableCaptureStackTrace = false;
             });
             using var provider = services.BuildServiceProvider();
-            var config = new DaemonPluginsConfig { GrantLevel = "High" };
+            var config = fixture.CreateConfig();
             var endpoints = new PluginHttpEndpointRegistry();
             var host = new PluginHost(
                 new SnapshotSource(new InstanceCatalogSnapshot([])),
@@ -991,7 +999,7 @@ public sealed class PluginHostLifecycleTests
                 fixture.PluginsRoot,
                 new PluginEventBus(provider.GetRequiredService<EventFactory>()),
                 TimeSpan.FromMilliseconds(500),
-                DaemonPluginsConfig.Default,
+                fixture.CreateConfig("Medium"),
                 new PluginHttpEndpointRegistry(),
                 rollbackCleanupTimeout: TimeSpan.FromMilliseconds(50),
                 shutdownCleanupTimeout: TimeSpan.FromMilliseconds(150));
@@ -1054,7 +1062,7 @@ public sealed class PluginHostLifecycleTests
                 options.EnableCaptureStackTrace = false;
             });
             using var provider = services.BuildServiceProvider();
-            var config = new DaemonPluginsConfig { GrantLevel = "High" };
+            var config = fixture.CreateConfig();
             var endpoints = new PluginHttpEndpointRegistry();
             var host = new PluginHost(
                 new SnapshotSource(new InstanceCatalogSnapshot([])),
@@ -1142,7 +1150,7 @@ public sealed class PluginHostLifecycleTests
                 options.EnableCaptureStackTrace = false;
             });
             using var provider = services.BuildServiceProvider();
-            var config = new DaemonPluginsConfig { GrantLevel = "High" };
+            var config = fixture.CreateConfig();
             var host = new PluginHost(
                 new SnapshotSource(new InstanceCatalogSnapshot([])),
                 new RecordingLoggerFactory(logger),
@@ -1406,6 +1414,18 @@ public sealed class PluginHostLifecycleTests
 
         public string PluginsRoot { get; }
 
+        public List<string> Ids { get; } = [];
+
+        // Spec section 4: absent entries mean disabled, so every fixture plugin needs an
+        // explicit opt-in record for the host to consider it at all.
+        public DaemonPluginsConfig CreateConfig(string grantLevel = "High")
+        {
+            var config = new DaemonPluginsConfig { GrantLevel = grantLevel };
+            foreach (var id in Ids)
+                config.Entries[id] = new PluginEntryConfig();
+            return config;
+        }
+
         public static PluginHostFixture Create(params (string Id, Assembly Assembly, string EntryType)[] plugins)
         {
             var fixture = new PluginHostFixture(Directory.CreateTempSubdirectory("mcsl-plugin-host-").FullName);
@@ -1469,6 +1489,7 @@ public sealed class PluginHostLifecycleTests
             string entryAssembly = "PluginEntry.dll",
             bool copyGeneratedDependencies = false)
         {
+            Ids.Add(id);
             var bundle = Path.Combine(PluginsRoot, id);
             Directory.CreateDirectory(bundle);
             File.Copy(assembly.Location, Path.Combine(bundle, entryAssembly));
@@ -1487,6 +1508,7 @@ public sealed class PluginHostLifecycleTests
             string[] features,
             bool copyPrivateDiDependency)
         {
+            Ids.Add(id);
             var bundle = Path.Combine(PluginsRoot, id);
             Directory.CreateDirectory(bundle);
             File.Copy(assemblyPath, Path.Combine(bundle, "PluginEntry.dll"));


### PR DESCRIPTION
## Summary

Spec section 4 states that a plugin id absent from `plugins.entries` is **disabled** (explicit opt-in required; the absence default is false). `PluginAdmissionPolicy.Decide` defaulted absent entries to enabled, so any bundle dropped into `plugins/` with features within the grant ceiling loaded silently without operator opt-in.

- `Decide` now returns `Enabled = false` unless an entries record exists with `enabled: true`.
- New policy/preflight tests pin the disabled-by-default behavior (`AbsentEntryDisablesPlugin`, `PreflightSkipsPluginAbsentFromEntries`); preflight reports `entry_disabled` without prompting.
- `PluginHostFixture` gains `CreateConfig`, registering entries for every fixture plugin id; all lifecycle/policy tests updated to opt their fixtures in explicitly.
- The published integration daemon `config.json` now writes explicit entries records for every deployed fixture plugin.
- `daemon-manual.md` / `plugin-developer-guide.md` document the operator opt-in requirement.

## Verification

- `MCServerLauncher.ProtocolTests` full suite: 1182/1182.
- `MCServerLauncher.PluginIntegrationTests` (published daemon, local run with `MCSL_PUBLISHED_DAEMON` + preview.3 package feed): 3/3.
- `git diff --check` clean.

Follow-up from the MCP-0..5 review (outstanding item 1 in the execution handoff).