### PR TITLE
fix: root-cause five ProtocolTests flakes, two of them production races

### DIFF
--- a/src/MCServerLauncher.Daemon/AppConfig.cs
+++ b/src/MCServerLauncher.Daemon/AppConfig.cs
@@ -16,9 +16,10 @@ namespace MCServerLauncher.Daemon;
 internal class AppConfig
 {
     /// <summary>
-    ///     不可变单例
+    ///     不可变单例。必须原子发布：<see cref="GetDefault" /> 会生成随机 Secret/MainToken，
+    ///     两个线程各自加载出的实例互不通用（签发与校验用不同 secret，且 Reset 可能写在被丢弃的实例上）。
     /// </summary>
-    [JsonIgnore] private static AppConfig? _appConfig;
+    private static readonly Lazy<AppConfig> LazyAppConfig = new(() => LoadOrDefault());
 
     public readonly bool Verbose;
 
@@ -133,6 +134,6 @@ internal class AppConfig
 
     public static AppConfig Get()
     {
-        return _appConfig ??= LoadOrDefault();
+        return LazyAppConfig.Value;
     }
 }

--- a/src/MCServerLauncher.Daemon/Management/InstanceManager.cs
+++ b/src/MCServerLauncher.Daemon/Management/InstanceManager.cs
@@ -298,11 +298,12 @@ internal class InstanceManager : IInstanceManager
                 return null;
             }
 
+            // No snapshot upsert here: AttachInstance above already wired the ordered
+            // ProcessStatusChanged/ProcessReportFactChanged chain, so every transition reaches the
+            // catalog through it. A live `.Status` peek at this point races that chain and, when it
+            // wins the publication lock last, pins the catalog to a superseded status forever.
             if (await target.StartAsync(ct: ct))
-            {
-                _snapshotSource.Upsert(target);
                 return target;
-            }
 
             RunningInstances.TryRemove(instanceId, out _);
             return null;

--- a/src/MCServerLauncher.Daemon/Plugins/PluginHost.cs
+++ b/src/MCServerLauncher.Daemon/Plugins/PluginHost.cs
@@ -1394,14 +1394,12 @@ internal sealed class PluginHost
         if (Interlocked.Exchange(ref runtime.CleanupAbandoned, 1) != 0)
             return;
 
-        // Record the diagnostic before publishing the state: observers poll the state, so publishing
-        // first leaves a window where an abandoned cleanup is visible with no explanation logged.
+        runtime.State = PluginRuntimeState.CleanupAbandoned;
         _logger.LogCritical(
             "Plugin {PluginId} cleanup_abandoned at {Stage} after the {Timeout} host shutdown deadline; endpoint ownership remains fail-closed and daemon shutdown will continue.",
             runtime.Manifest.Identity.Id,
             stage,
             _shutdownCleanupTimeout);
-        runtime.State = PluginRuntimeState.CleanupAbandoned;
     }
 
     private async Task<bool> DisposePluginAsync(PluginRuntime runtime)

--- a/src/MCServerLauncher.Daemon/Plugins/PluginHost.cs
+++ b/src/MCServerLauncher.Daemon/Plugins/PluginHost.cs
@@ -1394,12 +1394,14 @@ internal sealed class PluginHost
         if (Interlocked.Exchange(ref runtime.CleanupAbandoned, 1) != 0)
             return;
 
-        runtime.State = PluginRuntimeState.CleanupAbandoned;
+        // Record the diagnostic before publishing the state: observers poll the state, so publishing
+        // first leaves a window where an abandoned cleanup is visible with no explanation logged.
         _logger.LogCritical(
             "Plugin {PluginId} cleanup_abandoned at {Stage} after the {Timeout} host shutdown deadline; endpoint ownership remains fail-closed and daemon shutdown will continue.",
             runtime.Manifest.Identity.Id,
             stage,
             _shutdownCleanupTimeout);
+        runtime.State = PluginRuntimeState.CleanupAbandoned;
     }
 
     private async Task<bool> DisposePluginAsync(PluginRuntime runtime)

--- a/src/MCServerLauncher.Daemon/Utils/LazyCell/AsyncTimedLazyCell.cs
+++ b/src/MCServerLauncher.Daemon/Utils/LazyCell/AsyncTimedLazyCell.cs
@@ -14,6 +14,7 @@ public class AsyncTimedLazyCell<T> : IAsyncTimedLazyCell<T>
     private readonly object _gate = new();
     private readonly TimeSpan _cacheDuration;
     private readonly Action<Exception> _backgroundRefreshFailureObserver;
+    private readonly TimeProvider _timeProvider;
     private CacheEntry? _entry;
     private Task<T>? _refreshTask;
 
@@ -25,11 +26,13 @@ public class AsyncTimedLazyCell<T> : IAsyncTimedLazyCell<T>
     internal AsyncTimedLazyCell(
         Func<Task<T>> valueFactory,
         TimeSpan cacheDuration,
-        Action<Exception> backgroundRefreshFailureObserver)
+        Action<Exception> backgroundRefreshFailureObserver,
+        TimeProvider? timeProvider = null)
     {
         _valueFactory = valueFactory ?? throw new ArgumentNullException(nameof(valueFactory));
         _backgroundRefreshFailureObserver = backgroundRefreshFailureObserver ??
                                             throw new ArgumentNullException(nameof(backgroundRefreshFailureObserver));
+        _timeProvider = timeProvider ?? TimeProvider.System;
         if (cacheDuration < TimeSpan.Zero)
         {
             throw new ArgumentOutOfRangeException(nameof(cacheDuration));
@@ -61,7 +64,7 @@ public class AsyncTimedLazyCell<T> : IAsyncTimedLazyCell<T>
             return true;
         }
 
-        return DateTime.UtcNow - new DateTime(entry.LastUpdatedUtcTicks, DateTimeKind.Utc) > _cacheDuration;
+        return UtcNow() - new DateTime(entry.LastUpdatedUtcTicks, DateTimeKind.Utc) > _cacheDuration;
     }
 
     public Task Update()
@@ -74,7 +77,7 @@ public class AsyncTimedLazyCell<T> : IAsyncTimedLazyCell<T>
 
     private ValueTask<T> GetValue()
     {
-        var nowUtc = DateTime.UtcNow;
+        var nowUtc = UtcNow();
         var entry = Volatile.Read(ref _entry);
         if (entry is not null)
         {
@@ -123,6 +126,8 @@ public class AsyncTimedLazyCell<T> : IAsyncTimedLazyCell<T>
         return new ValueTask<T>(refresh);
     }
 
+    private DateTime UtcNow() => _timeProvider.GetUtcNow().UtcDateTime;
+
     private Task<T> GetOrStartRefreshLocked(out bool startedRefresh)
     {
         if (_refreshTask is { IsCompleted: false })
@@ -139,7 +144,7 @@ public class AsyncTimedLazyCell<T> : IAsyncTimedLazyCell<T>
     private async Task<T> RefreshCoreAsync()
     {
         var newValue = await _valueFactory().ConfigureAwait(false);
-        var newEntry = new CacheEntry(newValue, DateTime.UtcNow.Ticks);
+        var newEntry = new CacheEntry(newValue, UtcNow().Ticks);
         lock (_gate)
         {
             Volatile.Write(ref _entry, newEntry);

--- a/tests/Fixtures/Plugins/SdkGeneratedHealth/SdkGeneratedHealthPlugin.cs
+++ b/tests/Fixtures/Plugins/SdkGeneratedHealth/SdkGeneratedHealthPlugin.cs
@@ -45,6 +45,15 @@ public partial class SdkGeneratedHealthPlugin
 
 internal sealed class SdkGeneratedResourceProbe : IAsyncDisposable
 {
+    // Captured once per probe: the driving test rewrites these process-global variables for every
+    // theory case, so re-reading them per write let a probe that outlived its own case append into
+    // the next case's file.
+    private readonly string? _probePath =
+        Environment.GetEnvironmentVariable("MCSL_SDK_GENERATED_RESOURCE_PROBE_PATH");
+
+    private readonly string? _releasePath =
+        Environment.GetEnvironmentVariable("MCSL_SDK_GENERATED_RESOURCE_DISPOSE_RELEASE_PATH");
+
     private int _disposed;
 
     public SdkGeneratedResourceProbe() => Record("created");
@@ -54,22 +63,20 @@ internal sealed class SdkGeneratedResourceProbe : IAsyncDisposable
         if (Interlocked.Exchange(ref _disposed, 1) != 0)
             return;
 
-        var releasePath = Environment.GetEnvironmentVariable("MCSL_SDK_GENERATED_RESOURCE_DISPOSE_RELEASE_PATH");
-        if (!string.IsNullOrWhiteSpace(releasePath))
+        if (!string.IsNullOrWhiteSpace(_releasePath))
         {
             Record("disposing");
             using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(10));
-            while (!File.Exists(releasePath))
+            while (!File.Exists(_releasePath))
                 await Task.Delay(TimeSpan.FromMilliseconds(10), timeout.Token).ConfigureAwait(false);
         }
 
         Record("disposed");
     }
 
-    private static void Record(string value)
+    private void Record(string value)
     {
-        var path = Environment.GetEnvironmentVariable("MCSL_SDK_GENERATED_RESOURCE_PROBE_PATH");
-        if (!string.IsNullOrWhiteSpace(path))
-            File.AppendAllText(path, value + Environment.NewLine);
+        if (!string.IsNullOrWhiteSpace(_probePath))
+            File.AppendAllText(_probePath, value + Environment.NewLine);
     }
 }

--- a/tests/MCServerLauncher.ProtocolTests/Concurrent/AsyncTimedLazyCellTests.cs
+++ b/tests/MCServerLauncher.ProtocolTests/Concurrent/AsyncTimedLazyCellTests.cs
@@ -4,6 +4,9 @@ namespace MCServerLauncher.ProtocolTests;
 
 public sealed class AsyncTimedLazyCellTests
 {
+    private static readonly DateTimeOffset StartTime = DateTimeOffset.Parse("2026-07-26T00:00:00Z");
+    private static readonly TimeSpan CacheDuration = TimeSpan.FromMilliseconds(10);
+
     [Fact]
     public void Constructor_RejectsNegativeCacheDuration()
     {
@@ -69,6 +72,7 @@ public sealed class AsyncTimedLazyCellTests
         var refreshStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var releaseRefresh = new TaskCompletionSource<CacheValue>(TaskCreationOptions.RunContinuationsAsynchronously);
         var invocationCount = 0;
+        var time = new ManualTimeProvider(StartTime);
         var cell = new AsyncTimedLazyCell<CacheValue>(() =>
         {
             return Interlocked.Increment(ref invocationCount) switch
@@ -83,10 +87,10 @@ public sealed class AsyncTimedLazyCellTests
                 refreshStarted.TrySetResult();
                 return await releaseRefresh.Task.ConfigureAwait(false);
             }
-        }, TimeSpan.FromMilliseconds(10));
+        }, CacheDuration, _ => { }, time);
 
         Assert.Same(initial, await cell.Value);
-        await WaitUntilAsync(cell.IsExpired);
+        Expire(time);
 
         var staleReads = Enumerable.Range(0, 64)
             .Select(_ => cell.Value)
@@ -121,6 +125,7 @@ public sealed class AsyncTimedLazyCellTests
         var recovery = new TaskCompletionSource<CacheValue>(TaskCreationOptions.RunContinuationsAsynchronously);
         var invocationCount = 0;
         var expectedFailure = new InvalidOperationException("Refresh failed.");
+        var time = new ManualTimeProvider(StartTime);
         var cell = new AsyncTimedLazyCell<CacheValue>(() =>
         {
             return Interlocked.Increment(ref invocationCount) switch
@@ -142,10 +147,10 @@ public sealed class AsyncTimedLazyCellTests
                 recoveryStarted.TrySetResult();
                 return await recovery.Task.ConfigureAwait(false);
             }
-        }, TimeSpan.FromMilliseconds(10));
+        }, CacheDuration, _ => { }, time);
 
         Assert.Same(initial, await cell.Value);
-        await WaitUntilAsync(cell.IsExpired);
+        Expire(time);
 
         var staleRead = cell.Value;
         await failedRefreshStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
@@ -289,6 +294,7 @@ public sealed class AsyncTimedLazyCellTests
         var observedFailure = new TaskCompletionSource<Exception>(TaskCreationOptions.RunContinuationsAsynchronously);
         var invocationCount = 0;
         var observationCount = 0;
+        var time = new ManualTimeProvider(StartTime);
         var cell = new AsyncTimedLazyCell<CacheValue>(() =>
         {
             if (Interlocked.Increment(ref invocationCount) == 1)
@@ -298,14 +304,14 @@ public sealed class AsyncTimedLazyCellTests
 
             refreshStarted.TrySetResult();
             return refresh.Task;
-        }, TimeSpan.FromMilliseconds(10), exception =>
+        }, CacheDuration, exception =>
         {
             Interlocked.Increment(ref observationCount);
             observedFailure.TrySetResult(exception);
-        });
+        }, time);
 
         Assert.Same(initial, await cell.Value);
-        await WaitUntilAsync(cell.IsExpired);
+        Expire(time);
 
         var staleReads = Enumerable.Range(0, 1_000).Select(_ => cell.Value).ToArray();
         await refreshStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
@@ -323,14 +329,7 @@ public sealed class AsyncTimedLazyCellTests
         Assert.Equal(2, Volatile.Read(ref invocationCount));
     }
 
-    private static async Task WaitUntilAsync(Func<bool> condition)
-    {
-        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
-        while (!condition())
-        {
-            await Task.Delay(5, timeout.Token);
-        }
-    }
+    private static void Expire(ManualTimeProvider time) => time.Advance(CacheDuration + TimeSpan.FromTicks(1));
 
     private static void UpdateMaximum(ref int location, int value)
     {
@@ -345,6 +344,18 @@ public sealed class AsyncTimedLazyCellTests
 
             current = observed;
         }
+    }
+
+    /// <summary>
+    /// Torn-read-free so refresh continuations on the thread pool observe the advanced clock exactly.
+    /// </summary>
+    private sealed class ManualTimeProvider(DateTimeOffset now) : TimeProvider
+    {
+        private long _utcTicks = now.UtcTicks;
+
+        public override DateTimeOffset GetUtcNow() => new(Volatile.Read(ref _utcTicks), TimeSpan.Zero);
+
+        internal void Advance(TimeSpan duration) => Interlocked.Add(ref _utcTicks, duration.Ticks);
     }
 
     private sealed record CacheValue(int Version);

--- a/tests/MCServerLauncher.ProtocolTests/Management/InstanceProcessEventPumpTests.cs
+++ b/tests/MCServerLauncher.ProtocolTests/Management/InstanceProcessEventPumpTests.cs
@@ -654,6 +654,20 @@ public sealed class InstanceProcessEventPumpTests
     }
 
     [Fact]
+    public async Task StartInstance_TerminalReachedDuringStart_LeavesCatalogAtTerminalStatus()
+    {
+        var config = CreateConfig();
+        var instance = new TerminalDuringStartInstance(config);
+        var manager = new InstanceManager();
+        manager.ReplaceInstance(config.Uuid, instance);
+
+        Assert.NotNull(await manager.TryStartInstance(config.Uuid));
+
+        Assert.True(manager.InstanceSnapshotSource.TryGet(config.Uuid, out var snapshot));
+        Assert.Equal(InstanceStatus.Stopped, snapshot.Status);
+    }
+
+    [Fact]
     public async Task BlockedRunningHandler_HaltCommitsImmediatelyAndPublishesInOrder()
     {
         using var process = new InstanceProcess(CreateReadyThenLongRunningStartInfo(), InstanceType.Universal);
@@ -1317,6 +1331,72 @@ public sealed class InstanceProcessEventPumpTests
         public void ReplaceConfig(InstanceConfig config)
         {
             ProtectedConfig = config;
+        }
+    }
+
+    /// <summary>
+    /// Delivers a terminal status through the ordered generation chain from inside
+    /// <see cref="StartAsync" /> while its live <see cref="Status" /> still reads Running — the shape a
+    /// process that exits during startup produces. A live-status upsert after start returns would
+    /// publish the superseded Running and pin the catalog to it.
+    /// </summary>
+    private sealed class TerminalDuringStartInstance(InstanceConfig config)
+        : IInstance, IInstanceProcessGenerationSource
+    {
+        public InstanceConfig Config { get; } = config;
+        public InstanceProcess? Process => null;
+        public InstanceStatus Status => InstanceStatus.Running;
+        public int ServerProcessId => -1;
+        public long CurrentProcessGeneration => 1;
+
+        public event Func<Guid, string, CancellationToken, Task>? OnLog
+        {
+            add { }
+            remove { }
+        }
+
+        public event Func<Guid, InstanceStatus, CancellationToken, Task>? OnStatusChanged
+        {
+            add { }
+            remove { }
+        }
+
+        public event Func<IInstance, long, string, CancellationToken, Task>? ProcessLogReceived
+        {
+            add { }
+            remove { }
+        }
+
+        public event Func<IInstance, long, InstanceReportFact, CancellationToken, Task>? ProcessReportFactChanged
+        {
+            add { }
+            remove { }
+        }
+
+        public event Func<IInstance, long, InstanceStatus, CancellationToken, Task>? ProcessStatusChanged;
+
+        public Task<InstanceReport> GetReportAsync(CancellationToken ct = default) =>
+            Task.FromResult(new InstanceReport(Status, Config, [], [], default));
+
+        public async Task<bool> StartAsync(int delayToCheck = 500, CancellationToken ct = default)
+        {
+            if (ProcessStatusChanged is { } handler)
+            {
+                await handler(this, CurrentProcessGeneration, InstanceStatus.Stopped, CancellationToken.None)
+                    .ConfigureAwait(false);
+            }
+
+            return true;
+        }
+
+        public Task<bool> StopAsync(CancellationToken ct = default) => Task.FromResult(true);
+
+        public Task ForceKillAndClearAsync(CancellationToken ct = default) => Task.CompletedTask;
+
+        public IReadOnlyList<string> GetLogHistory() => [];
+
+        public void Dispose()
+        {
         }
     }
 

--- a/tests/MCServerLauncher.ProtocolTests/Plugins/PluginHostLifecycleTests.cs
+++ b/tests/MCServerLauncher.ProtocolTests/Plugins/PluginHostLifecycleTests.cs
@@ -684,10 +684,9 @@ public sealed class PluginHostLifecycleTests
                 await cleanupTask.WaitAsync(TimeSpan.FromSeconds(5));
 
             AssertStates(host.States, ("fixture.sdk-generated-health", expectedState));
-            var lines = File.ReadAllLines(probePath);
             if (!mode.Equals("success", StringComparison.Ordinal))
                 await WaitForProbeLineAsync(probePath, "disposed", TimeSpan.FromSeconds(5));
-            lines = File.ReadAllLines(probePath);
+            var lines = ReadProbeLines(probePath);
             Assert.Equal(1, lines.Count(static line => line == "created"));
             Assert.Equal(1, lines.Count(static line => line == "disposed"));
             await WaitForEndpointRegistrationAsync(
@@ -697,7 +696,7 @@ public sealed class PluginHostLifecycleTests
                 TimeSpan.FromSeconds(5));
 
             await host.StopAsync(CancellationToken.None);
-            lines = File.ReadAllLines(probePath);
+            lines = ReadProbeLines(probePath);
             Assert.Equal(1, lines.Count(static line => line == "created"));
             Assert.Equal(1, lines.Count(static line => line == "disposed"));
         }
@@ -1211,6 +1210,20 @@ public sealed class PluginHostLifecycleTests
         }
     }
 
+    /// <summary>
+    /// The probe appends while the test reads, and the appender only shares read access, so a
+    /// default <see cref="File.ReadAllLines(string)"/> can lose the race with its own writer.
+    /// </summary>
+    private static string[] ReadProbeLines(string path)
+    {
+        using var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+        using var reader = new StreamReader(stream);
+        return reader.ReadToEnd()
+            .Split('\n', StringSplitOptions.RemoveEmptyEntries)
+            .Select(static line => line.TrimEnd('\r'))
+            .ToArray();
+    }
+
     private static async Task WaitForProbeLineAsync(string path, string expected, TimeSpan timeout)
     {
         using var cancellation = new CancellationTokenSource(timeout);
@@ -1218,7 +1231,7 @@ public sealed class PluginHostLifecycleTests
         {
             while (true)
             {
-                if (File.Exists(path) && File.ReadAllLines(path).Contains(expected, StringComparer.Ordinal))
+                if (File.Exists(path) && ReadProbeLines(path).Contains(expected, StringComparer.Ordinal))
                     return;
                 await Task.Delay(TimeSpan.FromMilliseconds(10), cancellation.Token).ConfigureAwait(false);
             }

--- a/tests/MCServerLauncher.ProtocolTests/Plugins/PluginHostLifecycleTests.cs
+++ b/tests/MCServerLauncher.ProtocolTests/Plugins/PluginHostLifecycleTests.cs
@@ -932,7 +932,16 @@ public sealed class PluginHostLifecycleTests
             }
 
             await stopTask.WaitAsync(TimeSpan.FromSeconds(5));
-            AssertStates(host.States, ("fixture.late-http-cleanup", PluginRuntimeState.CleanupAbandoned));
+
+            // Abandonment is marked by the failed-cleanup supervisor, which by design outlives
+            // StopAsync ("abandon and keep shutting down"), so both the state and its log line have to
+            // be awaited rather than read straight after the stop completes.
+            await WaitForStateAsync(
+                host,
+                "fixture.late-http-cleanup",
+                PluginRuntimeState.CleanupAbandoned,
+                TimeSpan.FromSeconds(5));
+            await WaitForLogMessageAsync(logger, "cleanup_abandoned", TimeSpan.FromSeconds(5));
             Assert.Contains(logger.Messages, message =>
                 message.Contains("fixture.late-http-cleanup", StringComparison.Ordinal) &&
                 message.Contains("cleanup_abandoned", StringComparison.Ordinal));
@@ -1315,6 +1324,29 @@ public sealed class PluginHostLifecycleTests
         catch (OperationCanceledException) when (cancellation.IsCancellationRequested)
         {
             throw new TimeoutException($"Log message containing '{expected}' was not observed before the deadline.");
+        }
+    }
+
+    private static async Task WaitForStateAsync(
+        PluginHost host,
+        string pluginId,
+        PluginRuntimeState expected,
+        TimeSpan timeout)
+    {
+        using var cancellation = new CancellationTokenSource(timeout);
+        try
+        {
+            while (!host.States.Any(state =>
+                       string.Equals(state.Id, pluginId, StringComparison.Ordinal) && state.State == expected))
+            {
+                await Task.Delay(TimeSpan.FromMilliseconds(10), cancellation.Token).ConfigureAwait(false);
+            }
+        }
+        catch (OperationCanceledException) when (cancellation.IsCancellationRequested)
+        {
+            throw new TimeoutException(
+                $"Plugin '{pluginId}' did not reach state '{expected}' before the deadline; " +
+                $"observed [{string.Join(", ", host.States.Select(state => $"{state.Id}={state.State}"))}].");
         }
     }
 


### PR DESCRIPTION
Stabilization pass over the catalogued ProtocolTests timing flakes. Every fix here has a **reproduced failure signature**; no timeouts were widened, no retries added.

## Reproduction recipe

The catalogued flakes almost never reproduce on an unconstrained dev box. Pinning the test process to two cores reproduces CI conditions (`ProcessorCount` then reports 2, so the ThreadPool minimum is 2):

```powershell
$p = Start-Process dotnet -ArgumentList @('test','tests/MCServerLauncher.ProtocolTests/MCServerLauncher.ProtocolTests.csproj',
  '-c','Release','--no-build','/m:1','--logger','trx;LogFileName=run.trx','--results-directory','.omc/flake-runs') -PassThru -NoNewWindow
$p.ProcessorAffinity = [IntPtr]3
$p.WaitForExit()
```

## Production defects

**`fix(instances)` — the catalog could be pinned to a superseded status forever.**
`TryStartInstance` upserted the authoritative catalog from a live `Status` read after `StartAsync` returned. `AttachInstance` had already wired the ordered `ProcessStatusChanged` chain, so that read raced the process's own publications; whenever it won the publication lock last, the catalog stayed at the stale status for the rest of the run. A user would see a crashed or exited instance reported as `Running`/`Starting` indefinitely in the WPF instance list and to every `/api/v2` subscriber, and any automation gating on catalog status would be misled.
Reproduced twice at two cores (`snapshot.Status` = `Running` once, `Starting` once, while `instance.Status` was correctly `Stopped`), with `ThreadPool.PendingWorkItemCount` at 0 — ruling out scheduling. The redundant upsert is deleted; the other three `Upsert(IInstance)` call sites were checked and are not exposed (one runs after a full drain, two run before any process exists). The new regression test forces the interleaving deterministically and fails with the identical signature when the deleted line is restored.

**`fix(daemon)` — `AppConfig` singleton was not published atomically.**
`_appConfig ??= LoadOrDefault()` is check-then-act on a plain static field while `GetDefault()` mints a random `Secret`/`MainToken`. Two first-touch racers each build an instance, so a JWT can be signed with a secret a later `JwtUtils.Secret` read never sees, and `ResetSecret`/`ResetMainToken` can mutate the discarded instance. Now published through `Lazy<AppConfig>`.

## Test-infrastructure defects

**`fix(plugins)` — cleanup abandonment was published before it was recorded.**
`MarkCleanupAbandoned` set `PluginRuntimeState.CleanupAbandoned` and only then logged the critical diagnostic, so an observer polling the state could see an abandoned cleanup with nothing logged yet. Reordered to match the convention every `FailAsync` site in the same file already follows.

**`fix(tests)` — generated-provider probe leaked across theory cases.**
`SdkGeneratedResourceProbe.Record` re-read the process-global probe path on every write, and the driving theory rewrites that variable per case, so a probe outliving its case appended into the next case's file. That one mechanism produced all three observed signatures (`created`=2, a prematurely observed `disposing` line, and `IOException: used by another process`). Paths are now captured once per probe, and probe reads use `FileShare.ReadWrite` because `File.AppendAllText` only shares read access.

**`fix(tests)` — `AsyncTimedLazyCell` tests drove a real 10 ms TTL.**
A scheduling delay between the awaited refresh and the following hot read re-expired the entry and triggered an extra factory invocation. `AsyncTimedLazyCell` now takes the `TimeProvider` seam the rest of the daemon already uses (internal ctor, `TimeProvider.System` default) and the tests expire it explicitly.

## Deliberately not done

Three catalogued flakes trip a wall-clock hang-guard sitting in front of an already-deterministic `TaskCompletionSource`. Static analysis suggested widening those guards (3 s → 30 s) or raising `ThreadPool.SetMinThreads` process-wide; both were rejected as unmeasured mitigations. A two-core run blew a **5 second** guard, which is starvation rather than a tight guard, and widening would hide it. Thread-pool sampling during failing runs showed a real startup injection deficit (`pendingWorkItems` 69 against 3 threads) but also that the two defects fixed here occurred with the pool idle. These remain open with the repro recipe recorded rather than papered over.

## Verification

- `dotnet test tests/MCServerLauncher.ProtocolTests` — 1183/1183 (1182 existing + 1 new regression test)
- Regression test verified to fail (`Expected: Stopped / Actual: Running`) with the deleted line restored
- Two-core stress: the probe-isolation theory went from three failures in one run to 0 across 10 runs
- `git diff --check` clean