### PR TITLE
docs(agent-docs): auto-load AGENTS.md from the agent index

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,11 +1,13 @@
 # MCServerLauncher Future Agent Index
 
+@AGENTS.md
+
 ## Read First
 
 1. `PROJECT_PLAN.md` for product direction and fixed invariants.
 2. `RULES.md` for activation-scoped implementation rules.
 3. `EXECUTE_PLAN.md` for phase status and backlog.
-4. `AGENTS.md` for the full operating guide.
+4. `AGENTS.md` (auto-loaded every session via the import above) for the full operating guide.
 5. `skills/mcsl-future/SKILL.md` for domain-sensitive changes.
 6. `harness.md` for agent runtime workflow requirements (e.g. verify against `microsoft-docs` before writing .NET / Microsoft code).
 


### PR DESCRIPTION
## Summary

`CLAUDE.md` named `AGENTS.md` as "the full operating guide" but nothing actually pulled it
into an agent's context — it was only read if the agent happened to walk the Read First
list. This adds an `@AGENTS.md` import so the operating guide loads every session, and
annotates the list entry so the two do not read as duplicate instructions.

```diff
  # MCServerLauncher Future Agent Index

+ @AGENTS.md
+
  ## Read First
  ...
- 4. `AGENTS.md` for the full operating guide.
+ 4. `AGENTS.md` (auto-loaded every session via the import above) for the full operating guide.
```

## Notes

- Docs-only; no code, build, or test surface is touched, so no test battery was run.
- Split out of #59 deliberately — it is unrelated to the Preview-2 work and should not
  ride along with it.