### PR TITLE
build: restore the global.json SDK pin

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "10.0.201",
+    "rollForward": "disable"
+  }
+}


### PR DESCRIPTION
## Result — hypothesis CONFIRMED

CI on this branch **built successfully**: no `CS2012`, the Build solution (Release) step
passed and the run proceeded all the way into the test phase. Restoring the pin is the fix.

The run is still not fully green, for an unrelated reason: `1183/1184` tests passed, with
`InstanceProcessEventPumpTests.StopAllInstances_CommitsStoppingAndIgnoresBlockedLogConsumer`
failing on `System.TimeoutException`. That is the known hang-guard/timeout flake family, not
a build problem, and this branch contains nothing but `global.json`.

---

## Why

`master`'s `protocol-tests` has been red since `abfe0fcb`. Every run since fails the
**Build solution (Release)** step with the plugin generator project being compiled by two
MSBuild project instances at once:

```
CSC : error CS2012: Cannot open '...\generators\...\obj\Release\netstandard2.0\
      MCServerLauncher.Daemon.Plugin.Generators.dll' for writing
      -- because it is being used by another process
```

| commit | protocol-tests |
|---|---|
| `aad7d454` | pass (last green) |
| `d95e0b7f` | fail (different cause, not a build error) |
| `abfe0fcb` | **fail — CS2012 first appears** |
| `2f741468` | fail — CS2012 |

`abfe0fcb` ("test(protocol): copy dependency assembly for plugin tests") deleted
`global.json` alongside its unrelated fixture change. Without `global.json` the muxer picks
the highest installed SDK, so CI switched from `10.0.201` to the runner image's `10.0.301`.

Note `protocol-tests.yml:20` still declares `dotnet-version: '10.0.201'` — `setup-dotnet`
installs that SDK but cannot make the muxer select it. So CI's declared SDK and actual SDK
have been out of sync since `abfe0fcb`. This restores them to agreement.

## What this PR is, honestly

The duplicate-project-instance build graph is a **pre-existing latent hazard**: the generator
is both a solution member and an analyzer `ProjectReference` carrying
`SetTargetFramework="TargetFramework=netstandard2.0"`, which forks a second project instance
writing into the same `obj\Release\netstandard2.0`. Restoring the pin does not remove that
hazard — it restores the SDK under which it demonstrably does not fire.

I could not reproduce the failure locally on this machine under either `10.0.201` or
`10.0.302` (both cold-build clean, 20 cores), so **CI is the only environment where it
reproduces and therefore the only place this hypothesis can be tested**. If this PR goes
green, the pin is confirmed as the trigger; if it stays red, the hypothesis is wrong and the
build graph itself needs restructuring.

## Follow-ups worth tracking separately

- The latent duplicate-instance build graph should be de-forked regardless.
- Fixture projects under `tests/Fixtures/Plugins/*` are not solution members, so a solution
  build unsets their `Configuration` (`Microsoft.Common.CurrentVersion.targets:1584`) and they
  fall back to **Debug**. Verified by SHA-256 that the Debug-compiled fixture DLLs are the ones
  copied into the Release test output — so `-c Release` test runs load Debug-built plugins.
