### PR TITLE
docs(agent-docs): retire guidance that describes a project that no longer exists

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,7 +70,7 @@ MCServerLauncher-Future/
 ├── src/MCServerLauncher.Common/            # Shared models, utilities, protocol contracts
 ├── src/MCServerLauncher.Daemon.API/         # Transport-neutral application and plugin contracts
 ├── src/MCServerLauncher.Daemon/            # Background daemon managing instances
-├── generators/MCServerLauncher.Daemon.Generators/ # Transitional V1 action generator; delete at V2 cutover
+├── generators/MCServerLauncher.Daemon.Plugin.Generators/ # Plugin manifest/adapter source generator, packed into the SDK
 ├── src/MCServerLauncher.DaemonClient/      # .NET daemon client library
 ├── src/MCServerLauncher.WPF/               # Windows WPF client
 ├── tests/MCServerLauncher.ProtocolTests/     # Protocol and integration tests
@@ -131,10 +131,10 @@ MCServerLauncher-Future/
 - Use `System.Text.Json` exclusively for shared serialization assumptions.
 - Keep serialized contracts source-generation friendly and free of logging/runtime implementation dependencies.
 
-### V1 Action Generator
+### Plugin Source Generator
 
-- `generators/MCServerLauncher.Daemon.Generators` is transitional V1-only code.
-- Do not extend it. Remove the project, tests, benchmarks, solution entry, and runtime switch at the V2 deletion gate.
+- `generators/MCServerLauncher.Daemon.Plugin.Generators` produces plugin manifest and adapter code and is packed into the SDK package under `analyzers/dotnet/cs`. It is current, not transitional.
+- The transitional V1 action generator it is sometimes confused with is already deleted. `tools/VerifyNoV1Runtime.ps1` asserts it stays deleted, and that gate passes — do not go looking for a V1 generator to remove.
 
 ### Tests And Benchmarks
 
@@ -160,7 +160,7 @@ MCServerLauncher-Future/
 - Keep edits scoped to the requested behavior and touched areas.
 - Do not revert user or teammate changes without explicit instruction.
 - When the work changes behavior, update docs and tests in the same task.
-- Do not create or update `docs/superpowers/plans` history files, plan checklists, or plan changelogs unless the user explicitly asks for a durable plan.
+- Do not create or update plan history files, plan checklists, or plan changelogs under `docs/plan` or `docs/superpowers/plans` unless the user explicitly asks for a durable plan.
 - Before every commit, run `dotnet test tests/MCServerLauncher.ProtocolTests/MCServerLauncher.ProtocolTests.csproj /m:1` and confirm the full protocol test suite passes.
 - Commit messages use `type(scope): subject`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,4 +8,4 @@
 
 ## 2026-07-15
 
-- Completed the release-atomic V2 cutover and Phase 5 startup-plugin milestone. See [the execution plan](docs/superpowers/plans/2026-06-27-daemon-api-inprocess-plugin-v2-plan.md) for acceptance evidence.
+- Completed the release-atomic V2 cutover and Phase 5 startup-plugin milestone. Acceptance evidence lived in a working-note plan that was never tracked and no longer exists; `EXECUTE_PLAN.md` carries what survived of it.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ Use respectful, technical communication. Ground review feedback in evidence. Sta
 - Keep edits scoped to the task.
 - Update docs when behavior, vocabulary, or invariants change.
 - Run the smallest relevant verification before submitting.
-- Do not create or update `docs/superpowers/plans` history files or plan changelogs unless explicitly requested.
+- Do not create or update plan history files or plan changelogs unless explicitly requested.
 
 ## Commit Messages
 

--- a/EXECUTE_PLAN.md
+++ b/EXECUTE_PLAN.md
@@ -2,7 +2,9 @@
 
 ## Current Status
 
-The active architecture initiative is `docs/superpowers/plans/2026-06-27-daemon-api-inprocess-plugin-v2-plan.md`. It replaces the earlier additive V1/V2 design with an application-core-first, release-atomic V2 cutover followed by a startup-only trusted plugin host.
+The active architecture initiative replaced the earlier additive V1/V2 design with an application-core-first, release-atomic V2 cutover followed by a startup-only trusted plugin host. That cutover is complete; the plan document that drove it was a working note under the ignored `docs/superpowers/` tree and no longer exists, so this section is the surviving record of it rather than a pointer to one.
+
+Plans that still govern current work are tracked under `docs/plan/`, and the frozen decisions they answer to are under `docs/spec/`.
 
 The 2026-07-11 baseline is the V1 daemon at commit `925666a4`: Release protocol tests pass 382/382 after adding migration-only raw-binary, restart, file-transfer, file-operation, notification-producer, and subscription/reconnect characterization. The working tree also contains user-owned governance, review, harness, plan, and local-tool files; implementation must preserve those changes.
 

--- a/RULES.md
+++ b/RULES.md
@@ -6,7 +6,7 @@ Start by declaring touched areas: `docs`, `agent-docs`, `frontend`, `backend`, `
 
 ## Global Rules
 
-- Do not create or update `docs/superpowers/plans` history files, plan checklists, or plan changelogs unless the user explicitly asks for a durable plan.
+- Do not create or update plan history files, plan checklists, or plan changelogs under `docs/plan` or `docs/superpowers/plans` unless the user explicitly asks for a durable plan.
 - Git commit messages must use concise Conventional Commits: `type(scope): subject`.
 - Commit message titles must not contain long explanations.
 - Do not revert user or teammate changes without explicit instruction.
@@ -32,7 +32,7 @@ Start by declaring touched areas: `docs`, `agent-docs`, `frontend`, `backend`, `
 - JSON-RPC V2 execution and connection-owned outbound queues belong in `src/MCServerLauncher.Daemon/Remote/Rpc`.
 - WPF presentation and interaction logic belongs in `src/MCServerLauncher.WPF`.
 - Daemon connection and transport code belongs in `src/MCServerLauncher.DaemonClient`.
-- The retiring V1 action generator must not be extended; delete it when the V2 deletion gate is reached.
+- The V1 action generator is deleted and `tools/VerifyNoV1Runtime.ps1` keeps it that way; `generators/MCServerLauncher.Daemon.Plugin.Generators` is a different, current project and is not covered by that rule.
 
 ## Serialization And Protocol
 


### PR DESCRIPTION
Docs-only. Split out of #59 because it is unrelated to Preview-2 and a reviewer should not have to
read it alongside that diff.

## 1. AGENTS.md and RULES.md describe a deleted project

`AGENTS.md` listed this in the project structure:

```
├── generators/MCServerLauncher.Daemon.Generators/ # Transitional V1 action generator; delete at V2 cutover
```

and gave it a whole `### V1 Action Generator` section instructing its removal at the V2 deletion
gate. `RULES.md` repeated the instruction.

That project does not exist. The V1 deletion gate that asserts its absence
(`tools/VerifyNoV1Runtime.ps1`) **passes today**. The only directory under `generators/` is
`MCServerLauncher.Daemon.Plugin.Generators` — the plugin manifest/adapter source generator, which is
current and is packed into the SDK package under `analyzers/dotnet/cs`.

This is worse than ordinary staleness: an agent following the guide literally goes looking for a
generator to delete and finds the wrong one. That project is also the subject of #62, so it is
actively being worked on.

The `VerifyNoV1Runtime.ps1` entry naming the deleted path is left alone — asserting a path stays
absent is exactly what that gate is for.

## 2. The plan-history rule named a path that moved

`AGENTS.md`, `RULES.md` and `CONTRIBUTING.md` forbade creating plan history files under
`docs/superpowers/plans`. That directory is gitignored and now holds only closed per-PR remediation
notes; the plans that govern current work moved to `docs/plan/` (#59). The rule is restated by what
it forbids rather than by one path, so it survives the next move.

## 3. A dangling execution-plan link

`CHANGELOG.md` and `EXECUTE_PLAN.md` both linked
`docs/superpowers/plans/2026-06-27-daemon-api-inprocess-plugin-v2-plan.md`, which does not exist —
`EXECUTE_PLAN.md` called it "the active architecture initiative", so the document that governs phase
status pointed at a missing file.

I did not invent a replacement target. The plan was a working note under the ignored tree and is
gone; both places now say what survived and where current plans live.

This one was not in the original brief — it surfaced while grepping for the other two and is the
same class of defect, so it is fixed here rather than left for someone to trip over.

## Not touched

`skills/init-my-project/SKILL.md` also mentions `docs/superpowers/plans`, but that skill generates
guidance for *other* projects; its references are template boilerplate, not claims about this
repository.

## Verification

Docs-only, no code or build surface. `git diff --check` clean; grep confirms no remaining reference
to the deleted generator or the dangling plan in the governance docs.