### PR TITLE
fix(build): pin the SDK to a version CI has, and derive it in one place

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '10.0.201'
+          global-json-file: global.json
 
       - name: Find benchmark project
         id: benchmark_project

--- a/.github/workflows/protocol-tests.yml
+++ b/.github/workflows/protocol-tests.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '10.0.201'
+          global-json-file: global.json
 
       - name: Restore dependencies
         run: dotnet restore MCServerLauncher.slnx

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,7 +133,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: '10.0.201'
+          global-json-file: global.json
 
       - name: Restore project
         run: dotnet restore src/MCServerLauncher.Daemon/MCServerLauncher.Daemon.csproj
@@ -276,7 +276,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: '10.0.201'
+          global-json-file: global.json
 
       - name: Pack NuGet packages
         id: pack

--- a/.github/workflows/verify-preview1-package-pin.yml
+++ b/.github/workflows/verify-preview1-package-pin.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: 10.0.201
+          global-json-file: global.json
 
       - name: Create independent source trees
         shell: bash

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.302",
+    "version": "10.0.201",
     "rollForward": "disable"
   }
 }


### PR DESCRIPTION
**master is currently red.** Every `protocol-tests` job on `c785cae6` fails at restore:

```
A compatible .NET SDK was not found.
##[error]Process completed with exit code 1
```

`a54f6f9a` set `global.json` to `10.0.302` with `rollForward: disable`. The runners carry
`10.0.109`, `10.0.201`, `10.0.204` and `10.0.301` — not `10.0.302` — and
`.github/workflows/protocol-tests.yml` still asked `setup-dotnet` for `10.0.201`, so nothing on the
machine satisfied the pin.

## What this changes

1. `global.json` back to `10.0.201`. The runners have it, and it is the version the payload
   fingerprints in `docs/preview1-package-pin.md` and `docs/preview2-package-pin.md` are recorded
   against.
2. Every `setup-dotnet` step now uses `global-json-file: global.json` instead of restating a
   version.

## Why the second half matters more than the first

The pin and the workflows each stated the SDK independently, so they could disagree — and have now
done so **twice, in opposite directions**:

| | what happened | result |
|---|---|---|
| `abfe0fcb` | deleted `global.json`; workflows still said `10.0.201` | muxer silently chose the newest installed SDK (`10.0.301`); the generator's duplicate project instances began colliding and CI went red (fixed by #61) |
| `a54f6f9a` | pinned `10.0.302`; workflows still said `10.0.201` | no SDK on the machine matches; restore fails outright |

Restoring the pin alone would fix today's symptom and leave the mechanism in place for a third
occurrence. With `global-json-file` there is one statement of the version and no second place for it
to drift.

## For whoever hits this locally

`rollForward` is `disable`, so a machine whose default is `10.0.302` will not build. Install the
pinned SDK rather than bumping the pin:

```
dotnet-install --version 10.0.201
```

That friction is real, and the durable fix is to make a newer band safe rather than to widen the
pin: **#62** must be resolved before moving to `10.0.3xx`, because that band is exactly where the
generator's duplicate project instances collide. Bumping the pin without it re-creates the failure
#61 fixed.

## Verification

The failure is environmental to the runner image, so CI on this PR is the meaningful check — a green
`protocol-tests` here demonstrates both that the pinned SDK resolves and that `global-json-file`
supplies it correctly.