### PR TITLE
fix(build): build the plugin generator as one MSBuild instance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,6 +135,7 @@ MCServerLauncher-Future/
 
 - `generators/MCServerLauncher.Daemon.Plugin.Generators` produces plugin manifest and adapter code and is packed into the SDK package under `analyzers/dotnet/cs`. It is current, not transitional.
 - The transitional V1 action generator it is sometimes confused with is already deleted. `tools/VerifyNoV1Runtime.ps1` asserts it stays deleted, and that gate passes — do not go looking for a V1 generator to remove.
+- Every project reaching the generator must leave `TargetFramework` undefined for it. The generator is single-targeted, so the SDK builds it with that property removed, and the solution builds it as a member the same way; a reach path that adds the property produces a second MSBuild project instance writing the same `obj/` and `bin/`, which fails intermittently as `CS0006`, `CS2012`, `MSB3713` or `MSB3030`. Do not add `SetTargetFramework` to a `ProjectReference` pointing at it, and do not pass `TargetFramework` from an `<MSBuild>` task. `ProjectConfigurationTests.PluginGenerator_IsReachedWithTheSameGlobalPropertiesFromEveryProject` fails if either appears.
 
 ### Tests And Benchmarks
 

--- a/src/MCServerLauncher.Daemon.Plugin.Sdk/MCServerLauncher.Daemon.Plugin.Sdk.csproj
+++ b/src/MCServerLauncher.Daemon.Plugin.Sdk/MCServerLauncher.Daemon.Plugin.Sdk.csproj
@@ -35,9 +35,22 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="[10.0.9]" />
   </ItemGroup>
 
-  <!-- Analyzer/generator is packed into analyzers/dotnet/cs and does not flow as a compile asset. -->
+  <!--
+    Analyzer/generator is packed into analyzers/dotnet/cs and does not flow as a compile asset.
+
+    Do not add SetTargetFramework here. The generator is single-targeted, so the SDK already
+    builds it with TargetFramework *undefined* — Microsoft.Common.CurrentVersion.targets removes
+    the property precisely "to avoid another project evaluation". SetTargetFramework is the
+    metadata for a multi-targeted reference: it sets SkipGetTargetFrameworkProperties, which
+    suppresses that removal and then passes the value through as a global property. An MSBuild
+    project instance is keyed on (path, global properties), so the generator would be built once
+    with the property and once without — two instances writing one obj/ and bin/. The solution
+    lists this project as a member and builds it without the property, and no reference metadata
+    can change how the solution metaproject launches a member, so the only spelling that collapses
+    to a single instance is this one.
+  -->
   <ItemGroup>
-    <ProjectReference Include="..\..\generators\MCServerLauncher.Daemon.Plugin.Generators\MCServerLauncher.Daemon.Plugin.Generators.csproj" ReferenceOutputAssembly="false" OutputItemType="Analyzer" SetTargetFramework="TargetFramework=netstandard2.0" />
+    <ProjectReference Include="..\..\generators\MCServerLauncher.Daemon.Plugin.Generators\MCServerLauncher.Daemon.Plugin.Generators.csproj" ReferenceOutputAssembly="false" OutputItemType="Analyzer" />
   </ItemGroup>
 
   <ItemGroup>
@@ -47,16 +60,19 @@
   </ItemGroup>
 
   <!--
-    Build the generator, then add it to the package under analyzers/dotnet/cs.
-    The None item is created in a target so the path is resolved after the build
-    (project-evaluation-time Exists() would miss a fresh build output).
+    Add the generator to the package under analyzers/dotnet/cs.
+
+    The item is built in a target so the path is resolved after the build (a
+    project-evaluation-time Exists() would miss a fresh build output). The source is
+    @(Analyzer), which ResolveProjectReferences has already populated from the reference
+    above — deliberately not a second <MSBuild Targets="Build"> call on the generator. Such a
+    call carries its own global properties, and passing TargetFramework there forks the
+    generator into a second project instance exactly as SetTargetFramework would, moving the
+    duplicate build out of the build path and into the pack path where it is easier to miss.
   -->
   <Target Name="PackPluginGeneratorAsAnalyzer" BeforeTargets="GenerateNuspec;_GetPackageFiles" DependsOnTargets="ResolveProjectReferences">
-    <MSBuild Projects="..\..\generators\MCServerLauncher.Daemon.Plugin.Generators\MCServerLauncher.Daemon.Plugin.Generators.csproj" Targets="Build" Properties="Configuration=$(Configuration);TargetFramework=netstandard2.0">
-      <Output TaskParameter="TargetOutputs" ItemName="_PluginGeneratorBuildOutputs" />
-    </MSBuild>
     <ItemGroup>
-      <_PluginGeneratorOutput Include="@(_PluginGeneratorBuildOutputs)" Condition="'%(Filename)%(Extension)' == 'MCServerLauncher.Daemon.Plugin.Generators.dll'" />
+      <_PluginGeneratorOutput Include="@(Analyzer)" Condition="'%(Filename)%(Extension)' == 'MCServerLauncher.Daemon.Plugin.Generators.dll'" />
       <_PluginGeneratorVersioningOutput Include="@(_PluginGeneratorOutput->'%(RootDir)%(Directory)NuGet.Versioning.dll')" />
     </ItemGroup>
     <Error Condition="'@(_PluginGeneratorOutput)' == '' Or !Exists('@(_PluginGeneratorOutput->'%(FullPath)')')" Text="The plugin generator build did not return its output DLL." />

--- a/tests/Fixtures/Plugins/SdkGeneratedHealth/SdkGeneratedHealth.csproj
+++ b/tests/Fixtures/Plugins/SdkGeneratedHealth/SdkGeneratedHealth.csproj
@@ -9,10 +9,10 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\src\MCServerLauncher.Daemon.Plugin.Sdk\MCServerLauncher.Daemon.Plugin.Sdk.csproj" />
+    <!-- No SetTargetFramework: see the reference in MCServerLauncher.Daemon.Plugin.Sdk.csproj. -->
     <ProjectReference Include="..\..\..\..\generators\MCServerLauncher.Daemon.Plugin.Generators\MCServerLauncher.Daemon.Plugin.Generators.csproj"
                       OutputItemType="Analyzer"
-                      ReferenceOutputAssembly="false"
-                      SetTargetFramework="TargetFramework=netstandard2.0" />
+                      ReferenceOutputAssembly="false" />
     <PackageReference Include="NuGet.Versioning"
                       Version="6.14.3"
                       GeneratePathProperty="true"

--- a/tests/MCServerLauncher.ProtocolTests/Configuration/ProjectConfigurationTests.cs
+++ b/tests/MCServerLauncher.ProtocolTests/Configuration/ProjectConfigurationTests.cs
@@ -132,6 +132,70 @@ public class ProjectConfigurationTests
         Assert.Contains($"'\\b{legacyType}\\b'", script, StringComparison.Ordinal);
     }
 
+    /// <summary>
+    /// MSBuild keys a project instance on (project path, global properties), so two reach paths
+    /// that disagree about whether <c>TargetFramework</c> is defined build the plugin generator
+    /// twice into one <c>obj/</c> and <c>bin/</c> — concurrently, under a parallel build.
+    /// </summary>
+    /// <remarks>
+    /// Convergence has to be onto the *undefined* form. The generator is a member of
+    /// <c>MCServerLauncher.slnx</c>, the solution metaproject builds a member with no
+    /// <c>TargetFramework</c> global property, and no reference metadata in any consuming project
+    /// can change that — so the property can never be added everywhere, only removed everywhere.
+    /// Both spellings that add it are checked here: <c>SetTargetFramework</c>, which is the
+    /// metadata for a *multi*-targeted reference and on this single-targeted one both injects the
+    /// global property and suppresses the SDK negotiation that would have removed it, and an
+    /// explicit <c>&lt;MSBuild&gt;</c> task passing the property in <c>Properties</c>.
+    /// </remarks>
+    [Fact]
+    public void PluginGenerator_IsReachedWithTheSameGlobalPropertiesFromEveryProject()
+    {
+        var repositoryRoot = GetRepositoryRoot();
+        var projectRoots = new[] { "src", "tests", "generators", "benchmarks", "tools", "samples" };
+        var offenders = projectRoots
+            .Select(root => Path.Combine(repositoryRoot, root))
+            .Where(Directory.Exists)
+            .SelectMany(root => Directory.EnumerateFiles(root, "*.csproj", SearchOption.AllDirectories))
+            .Where(path => !HasGeneratedPathSegment(path))
+            .SelectMany(path => DescribeGeneratorForks(path, repositoryRoot))
+            .ToArray();
+
+        Assert.True(
+            offenders.Length == 0,
+            "The plugin generator would be built as more than one MSBuild instance:"
+            + Environment.NewLine
+            + string.Join(Environment.NewLine, offenders));
+    }
+
+    private static IEnumerable<string> DescribeGeneratorForks(string projectPath, string repositoryRoot)
+    {
+        var document = XDocument.Load(projectPath);
+        var relativePath = Path.GetRelativePath(repositoryRoot, projectPath);
+
+        var references = document
+            .Descendants("ProjectReference")
+            .Where(element => TargetsPluginGenerator(element.Attribute("Include")?.Value))
+            .Where(element =>
+                element.Attribute("SetTargetFramework") is not null ||
+                element.Element("SetTargetFramework") is not null)
+            .Select(_ => $"{relativePath}: ProjectReference carries SetTargetFramework.");
+
+        var invocations = document
+            .Descendants("MSBuild")
+            .Where(element => TargetsPluginGenerator(element.Attribute("Projects")?.Value))
+            .Where(element => (element.Attribute("Properties")?.Value ?? string.Empty)
+                .Contains("TargetFramework", StringComparison.OrdinalIgnoreCase))
+            .Select(_ => $"{relativePath}: <MSBuild> task passes TargetFramework.");
+
+        return references.Concat(invocations);
+    }
+
+    private static bool TargetsPluginGenerator(string? include) =>
+        include is not null &&
+        include.Replace('\\', '/').EndsWith(
+            "generators/MCServerLauncher.Daemon.Plugin.Generators/MCServerLauncher.Daemon.Plugin.Generators.csproj",
+            StringComparison.OrdinalIgnoreCase);
+
     private static string GetRepositoryRoot()
     {
         var directory = AppContext.BaseDirectory;


### PR DESCRIPTION
Closes #62.

## 根因

MSBuild 以 `(工程路径, 全局属性集)` 作为 project instance 的标识。generator 被两组不同的全局属性触达：

| 配置 | 全局属性 | 由谁产生 |
|---|---|---|
| **X** | 无 `TargetFramework` | `MCServerLauncher.slnx` 成员；`Generators.Tests` 的普通 ProjectReference |
| **Y** | `TargetFramework=netstandard2.0` | SDK 引用与 fixture 引用的 `SetTargetFramework`；`PackPluginGeneratorAsAnalyzer` 里的 `<MSBuild>` 任务 |

generator 是单 TFM 工程，所以 `GetTargetFrameworks` 恒返回 `HasSingleTargetFramework=true`，`_GetProjectReferenceTargetFrameworkProperties` 会走"把 `TargetFramework` 加入 `UndefineProperties`"的分支——SDK 自己的注释写的就是 **"to avoid another project evaluation"**。`SetTargetFramework` 会置 `SkipGetTargetFrameworkProperties=true`，既跳过那次移除，又把值当全局属性传下去。它是自我强化的：注入属性，同时压掉本会移除它的代码。

两个实例写同一个 `obj/` 和 `bin/`。

## 为什么 issue 里三次实验都失败

同一个模型一次解释三次：**引用元数据能给子工程"加"全局属性，但永远无法让 solution metaproject 给成员"加"一个。** 所以只能向 X 收敛，不能向 Y 收敛。

- 实验 1（给 tests 也加 `SetTargetFramework`）→ 把路径 5 挪到 Y，slnx 成员仍在 X。剩 2 个。
- 实验 2（三个引用都去掉 `SetTargetFramework`）→ 2/4/5 到 X，但 `<MSBuild>` 任务仍在 Y。剩 2 个，表现为 `MSB3030`。
- 实验 3（保留 `SetTargetFramework`，把 generator 移出 slnx）→ 删掉一个 X 来源，但 `Generators.Tests` 的普通引用还是 X。剩 2 个。

顺带纠正 issue 的一处描述：`Generators.Tests` **不是 #59 引入的**，它在 master 上就存在，master 的 SDK csproj 也已带 `SetTargetFramework`。这是 master 级缺陷，所以本 PR 直接基于 master。

`<MSBuild>` 任务不是历次失败的原因——它挂在 `GenerateNuspec;_GetPackageFiles` 上，`dotnet build` 时根本不运行。但它是**正确修复的陷阱**：只删 `SetTargetFramework` 而不动它，重复构建会从 build 路径搬到 pack 路径（实测 pack 的 generator 构建 1 → 2），更难被发现。所以两处必须同时改。

## 测量

冷构建，同一台机器，同一命令，两臂对照。探针经 `CustomAfterMicrosoftCommonTargets` **环境变量**注入（不用 `/p:`，以免探针本身改变被测的全局属性集），并用 `%(ModifiedTime)` 区分"真编译"与"到达但跳过"。

| 场景 | baseline | 本 PR |
|---|---|---|
| `dotnet build tests/…Generators.Tests` | 2 reach，**3 次里硬失败 2 次 CS0006** | 1 reach，0 error（3/3） |
| `dotnet build MCServerLauncher.slnx -c Release` | 2 reach，靠约 2 秒调度间隔侥幸躲过 | 1 reach，0 error |
| `dotnet pack …Plugin.Sdk` | 1 reach（`<MSBuild>` 与 SDK 引用去重到同一配置） | 1 reach |

```
CSC : error CS0006: Metadata file '…\Plugin.Generators\bin\Release\netstandard2.0\
MCServerLauncher.Daemon.Plugin.Generators.dll' could not be found
```

**这与 issue 的一处判断相反。** issue 写 #61 恢复的 pin"restores the SDK under which this hazard does not currently fire"。实测在 `10.0.201` 上它**会**触发，只是间歇——解决方案构建靠调度间隔躲过，单独构建测试工程 3 次挂 2 次。所以 #61 没有把危害压住，只是让它更少露头。

## 变更

- `src/MCServerLauncher.Daemon.Plugin.Sdk.csproj`：去掉 `SetTargetFramework`；`PackPluginGeneratorAsAnalyzer` 改从 `@(Analyzer)` 取路径，删掉那次 `<MSBuild Targets="Build">`。两个 `<Error>` 守卫**原文未动**。
- `tests/Fixtures/Plugins/SdkGeneratedHealth.csproj`：去掉 `SetTargetFramework`。
- `ProjectConfigurationTests.PluginGenerator_IsReachedWithTheSameGlobalPropertiesFromEveryProject`：静态断言不变量。
- `AGENTS.md`：记下不变量与失败形状。

守卫刻意做成**静态**的：遍历全部 csproj，断言没有指向 generator 的 `SetTargetFramework`，也没有 `<MSBuild>` 任务给它传 `TargetFramework`。不数构建日志行数——那依赖日志渲染，换成 terminal logger 会静默变 0。而这条修复的形状是"删掉几个看似必要的属性"，issue 已经记录它被"改回去"过一次，所以真实的回归形状正是有人把属性加回来，静态检查恰好覆盖。

**负向对照**：对修复前的工程文件，该测试红并逐点列出三处（SDK 的 ProjectReference、SDK 的 `<MSBuild>` 任务、fixture 的 ProjectReference）；修复后绿。

## 验证

在 `/d/wt62s`（短路径，见下）跑，本地把 `global.json` 临时降到 `10.0.201`（master 钉 `10.0.302`，本机未安装），**提交前已还原**：

- ProtocolTests `1198/1198`
- generator tests `51/51`
- 整解决方案 Release 构建：`0 warning / 0 error`
- pin 参数 pack：`analyzers/dotnet/cs` 两个条目齐全，`<Error>` 守卫仍会触发
- 冷跑 reproducer ×3：均 1 个实例
- `git diff --check` 干净

## 两处与本 PR 无关的既有问题（已证明既有）

我把两者都做了纯净 master 对照，均在**完全还原本 PR 改动**后一样失败：

1. **`PublicApiBaselineTests.CommonContractsPublicApiMatchesTheReviewedFirstReleaseBaseline` 在 master 上失败**（`BinaryFrameReadResult.ActualPayloadLength`），删掉 bin/obj 排除陈旧副本后仍失败。CI 的四项检查不含 ApiTests，所以 master CI 仍显示绿——**master 上有一条 CI 不跑的失败测试**。

2. 我最初在 scratchpad 下的 worktree 里看到两条 `InstanceProcessEventPumpTests` 失败，一度以为是 master 红了。实为 **MAX_PATH**：实例脚本路径 263 字符 > 260，`Process.Start` 报"找不到文件"。换到 `/d/wt62s` 后同样 48 条全过。记在这里，免得下一个人重复误判。
