### PR TITLE
fix(backend): bound the wait for a process drain, not the drain itself

### DIFF
--- a/src/MCServerLauncher.Daemon/Management/InstanceBase.cs
+++ b/src/MCServerLauncher.Daemon/Management/InstanceBase.cs
@@ -13,6 +13,12 @@ public abstract class InstanceBase : DisposableObject, IInstance, IInstanceRepor
 {
     private const int MaximumLogHistoryLines = 500;
     private const string LifecycleLogPrefix = "[MCSL] Instance";
+
+    /// <summary>
+    /// How long a halt or a restart waits for the previous generation to finish draining before it
+    /// detaches the generation and lets the rest finish in the background.
+    /// </summary>
+    private static readonly TimeSpan DefaultDrainDeadline = TimeSpan.FromSeconds(5);
     private readonly Func<ProcessStartInfo, InstanceType, ConsoleMode, InstanceProcess> _processFactory;
     private readonly object _processBindingGate = new();
     private ProcessBinding? _processBinding;
@@ -102,7 +108,7 @@ public abstract class InstanceBase : DisposableObject, IInstance, IInstanceRepor
         // attached via Process.GetProcessById; after Kill/halt HasExited may stay false, which
         // previously made the next StartAsync return false permanently until daemon restart.
         if (Volatile.Read(ref _processBinding) is { } existingBinding)
-            await DisposeManagedProcessAsync(existingBinding, ct).ConfigureAwait(false);
+            await DisposeManagedProcessAsync(existingBinding, DefaultDrainDeadline, ct).ConfigureAwait(false);
 
         var startInfoResult = Config.TryGetStartInfo();
         if (startInfoResult.IsErr(out var error))
@@ -168,27 +174,14 @@ public abstract class InstanceBase : DisposableObject, IInstance, IInstanceRepor
     /// Immediately kills the managed process and drops <see cref="Process"/> so a later
     /// <see cref="StartAsync"/> cannot be blocked by a stale HasExited=false handle.
     /// </summary>
-    public async Task ForceKillAndClearAsync(CancellationToken ct = default)
+    public Task ForceKillAndClearAsync(CancellationToken ct = default) =>
+        ForceKillAndClearAsync(DefaultDrainDeadline, ct);
+
+    internal async Task ForceKillAndClearAsync(TimeSpan drainDeadline, CancellationToken ct = default)
     {
         ct.ThrowIfCancellationRequested();
-        var binding = Volatile.Read(ref _processBinding);
-        if (binding is null)
-            return;
-        var process = binding.Source;
-
-        try
-        {
-            // Once termination is requested, the per-instance manager gate must remain held
-            // until the old operating-system process tree and lifecycle publications drain.
-            await process.KillAndDrainAsync(ct).ConfigureAwait(false);
-        }
-        catch (Exception exception)
-        {
-            Log.Warning(exception, "[Instance] Process-tree halt failed for '{InstanceId}'", Config.Uuid);
-            throw;
-        }
-
-        ResetProcess(binding);
+        if (Volatile.Read(ref _processBinding) is { } binding)
+            await DisposeManagedProcessAsync(binding, drainDeadline, ct).ConfigureAwait(false);
     }
 
     public IReadOnlyList<string> GetLogHistory()
@@ -232,26 +225,70 @@ public abstract class InstanceBase : DisposableObject, IInstance, IInstanceRepor
         await InvokeAsync(OnLog, Config.Uuid, message, cancellationToken).ConfigureAwait(false);
     }
 
-    private async Task DisposeManagedProcessAsync(ProcessBinding binding, CancellationToken ct)
+    /// <summary>
+    /// Terminates the process tree and detaches the generation. Starting a new generation waits for
+    /// the previous process tree, output and lifecycle publication tail to drain — but the deadline
+    /// bounds that wait, never the work behind it.
+    /// </summary>
+    /// <remarks>
+    /// Nothing in the drain is ours to bound. A redirected pipe reaches EOF only when the last
+    /// inherited copy of its write handle closes anywhere on the machine, and the publication tail is
+    /// only as fast as its slowest subscriber. Waiting on a party we do not control while holding the
+    /// per-instance mutation gate is what wedges every later operation on the instance — and on the
+    /// restart path it is worse, because a generation that never finishes draining means the instance
+    /// can never start again.
+    /// </remarks>
+    private async Task DisposeManagedProcessAsync(
+        ProcessBinding binding,
+        TimeSpan drainDeadline,
+        CancellationToken ct)
     {
-        var process = binding.Source;
+        var drain = binding.Source.KillAndDrainAsync(ct);
         try
         {
-            // Starting a new generation is forbidden until the previous process tree, output,
-            // and lifecycle publication tail have fully drained.
-            await process.KillAndDrainAsync(ct).ConfigureAwait(false);
+            await drain.WaitAsync(drainDeadline).ConfigureAwait(false);
+        }
+        catch (TimeoutException)
+        {
+            // Detaching is what fences the straggler, and it is safe here because termination was
+            // already requested and the terminal status already committed, synchronously, before the
+            // drain's first await. Every publication path re-checks the current binding, so once the
+            // binding is gone the abandoned generation can no longer reach the catalog however long
+            // it takes to finish.
+            Log.Warning(
+                "[Instance] Process drain exceeded {DrainDeadline} for '{InstanceId}'; detaching the old generation and letting it finish in the background.",
+                drainDeadline,
+                Config.Uuid);
+            ObserveDetachedDrain(drain);
         }
         catch (Exception exception)
         {
+            // The drain failed rather than outran us, so the kill is not known to have taken. Keep
+            // the binding and report the failure instead of a false halt success.
             Log.Warning(
                 exception,
-                "[Instance] Failed to drain stale process before restart for '{InstanceId}'",
+                "[Instance] Failed to drain the process tree for '{InstanceId}'",
                 Config.Uuid);
             throw;
         }
 
         ResetProcess(binding);
     }
+
+    /// <summary>
+    /// Keeps an abandoned drain's failure from surfacing as an unobserved task exception. There is
+    /// nothing to do about it beyond recording it: the generation is already fenced.
+    /// </summary>
+    private void ObserveDetachedDrain(Task drain) =>
+        _ = drain.ContinueWith(
+            static (task, state) => Log.Warning(
+                task.Exception,
+                "[Instance] Detached process drain for '{InstanceId}' faulted after its deadline.",
+                state),
+            Config.Uuid,
+            CancellationToken.None,
+            TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
 
     private ProcessBinding AttachProcess(InstanceProcess process)
     {

--- a/tests/MCServerLauncher.ProtocolTests/Management/InstanceProcessEventPumpTests.cs
+++ b/tests/MCServerLauncher.ProtocolTests/Management/InstanceProcessEventPumpTests.cs
@@ -935,6 +935,52 @@ public sealed class InstanceProcessEventPumpTests
         }
     }
 
+    /// <summary>
+    /// The drain waits on parties the daemon does not control — a redirected pipe reaches EOF only
+    /// when the last inherited copy of its write handle closes anywhere on the machine, and the
+    /// publication tail is only as fast as its slowest subscriber. The deadline bounds the wait, not
+    /// the work: the old generation is fenced on time and the rest finishes in the background.
+    /// </summary>
+    [Fact]
+    public async Task InstanceBase_ForceKillDetachesTheGenerationWhenTheDrainOutlastsItsDeadline()
+    {
+        using var stuckProcess = new InstanceProcess(CreateReadyThenLongRunningStartInfo(), InstanceType.Universal);
+        using var nextProcess = new InstanceProcess(CreateReadyThenLongRunningStartInfo(), InstanceType.Universal);
+        var instance = new FactoryBackedInstance(CreateConfig(), stuckProcess, nextProcess);
+        var parked = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        try
+        {
+            Assert.True(await instance.StartAsync());
+
+            // Subscribed after Start so only the halt's own terminal publication parks. A subscriber
+            // that never returns stands in for every party the drain cannot bound.
+            stuckProcess.OnStatusChanged += async (status, _) =>
+            {
+                if (status != InstanceStatus.Stopped)
+                    return;
+
+                parked.TrySetResult();
+                await release.Task;
+            };
+
+            var halt = instance.ForceKillAndClearAsync(TimeSpan.FromMilliseconds(200));
+            await parked.Task.WaitAsync(TestTimeout);
+            await halt.WaitAsync(TestTimeout);
+
+            // Bounded without weakening the invariant: the old generation is detached, so the drain
+            // still running behind it can no longer reach the catalog, and the next one may attach.
+            Assert.Null(instance.Process);
+            Assert.True(await instance.StartAsync());
+            Assert.Same(nextProcess, instance.Process);
+        }
+        finally
+        {
+            release.TrySetResult();
+            instance.Dispose();
+        }
+    }
+
     [Fact]
     public async Task InstanceBase_OldGenerationReadyTimeoutCannotRegressRestartedCatalog()
     {


### PR DESCRIPTION
Closes #70.

调查过程中 **#70 原本的诊断被推翻了**，更正已发在该 issue 下；这里只讲结论。

## 责任方不是 issue 里写的那个

#70 和代码注释都把 14 分钟归给生命周期发布尾部。但测试的 `finally` 在调用 `ForceKillAndClearAsync` **之前**就已 `releaseOldTimeout.TrySetResult()`——屏障是放开的，执行根本走不到那一步。

`KillAndDrainAsync`（`InstanceProcess.cs:319`）里有**三处**外部方可致永不完成：

| 位置 | 谁能让它停住 |
|---|---|
| `:336-337` 子孙进程退出 | 不死的孙进程 |
| `:344` → `:602` 裸 `await pumps` | 管道 EOF。`PumpAsync` 的读硬编码 `CancellationToken.None`（`:460`），所以 `_pumpCancellation.Cancel()` 无效，`:468` 那个 catch 在此路径是死代码。Windows 匿名管道的 EOF 只在**机器上最后一份写句柄副本**关闭时到达，包括被无关进程继承的 |
| `:354` 发布尾部 | 被阻塞的订阅者 |

**两次独立追踪对"究竟是哪一处"给出不同倾向，都没有 dump 佐证。** 所以本 PR 不猜——在**调用方**加一次 `WaitAsync`，一次覆盖三处，diff 也比分别加界更小。

冒烟证据：PTY 分支 `:590` **早就**给同一危险加了 2 秒上界并带回退，紧邻的管道分支 `:600-603` 却是光秃秃的 `await pumps`。一半已经被人加过界了。

## 这是生产缺陷，测试只是信使

- `InstanceManager.KillInstanceAsync` 全程持有 mutation admission **和**该实例的 gate，一次卡死让该实例之后所有 start/stop/kill/remove/settings **永久排队**；halt RPC 不返回；WPF 上是按钮无响应且无报错。
- **更坏的一个**：同一个排空在 `StartAsync` → `DisposeManagedProcessAsync` 路径上。第 N 代卡住的排空让该实例**永远无法再启动**，直到 daemon 重启。
- halt RPC 把客户端取消令牌忠实转发进了一个不会遵守它的调用——`KillAndDrainAsync` 只在入口检查一次，之后每个 await 都忽略。

## 修法

与插件能力撤销（`fix(plugins): bound the whole revocation…`）同形，但更小——不需要 memoized sweep 字段，因为 `ResetProcess` 在超时路径上就清掉绑定。

**限的是等待，不是工作**：不取消任何东西，排空照常在后台跑完。

**gate 不变量不被削弱**：它从来不是靠"持有 gate 等待"保证的，而是靠 fencing——而 fencing 现在在超时路径上**也**会发生，此前那条路径是跳过它的。会因半排空实例出错的具体操作是 `StartAsync`：旧代 `FinalizeProcessAsync` 末尾的 `PublishStoppedAsync()` 若落在新代已提交 `Running` 之后会让目录回退。每条发布路径都会重新检查当前绑定，所以绑定一旦解除，被遗弃的那一代**再也够不到目录**，无论它还要跑多久。

排空**失败**（而非超时）仍保留绑定并抛出——那时无法确认 kill 是否生效，不能报告虚假的 halt 成功。

顺带把 `ForceKillAndClearAsync` 与 `DisposeManagedProcessAsync` 这对近乎重复的方法合并，上界只存在一处。

## 负向对照

去掉 `WaitAsync(drainDeadline)`、其余改动保留，新测试的 `halt` 不返回，在 969 行 5 秒上限处失败：

```
System.TimeoutException : The operation has timed out.
   at ...InstanceBase_ForceKillDetachesTheGenerationWhenTheDrainOutlastsItsDeadline() ...:line 969
```

加回上界后通过（2 秒）。测试用一个永不返回的订阅者作为"daemon 无法约束的一方"的替身，确定性触发，不是竞态。

## 验证

全新重建（先清空全部 obj/bin）：整解决方案 **0 warning / 0 error**；ProtocolTests **1373/1373**；Daemon.ApiTests 116/116；`git diff --check` 干净。

## 不在本 PR 内

`InstanceProcessEventPumpTests.cs:986` 的 3 秒上限。它该调，但单独一个提交，且在这个之后——而且那条测试的 `Assert.False(haltTask.IsCompleted)`（`:982`）并不能证明它读起来要证明的事：坏运行里 `haltTask` 早已停在排空上而非屏障上，放开屏障对它毫无作用。
