### PR TITLE
fix(backend,tests): unpin production workers from the xunit scheduler and stop starving it

### DIFF
--- a/.github/workflows/protocol-tests.yml
+++ b/.github/workflows/protocol-tests.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   protocol-tests:
     runs-on: windows-latest
+    # Backstop only. The blame collector below should name the stuck test first;
+    # without this a hang would burn the 6-hour default before anyone notices.
+    timeout-minutes: 30
 
     steps:
       - name: Checkout code
@@ -26,4 +29,14 @@ jobs:
         run: dotnet build MCServerLauncher.slnx -c Release --no-restore
 
       - name: Run protocol tests (Release)
-        run: dotnet test tests/MCServerLauncher.ProtocolTests/MCServerLauncher.ProtocolTests.csproj -c Release --no-build --logger "console;verbosity=detailed"
+        run: dotnet test tests/MCServerLauncher.ProtocolTests/MCServerLauncher.ProtocolTests.csproj -c Release --no-build --logger "console;verbosity=detailed" --blame-hang --blame-hang-timeout 8m --blame-hang-dump-type mini --results-directory TestResults
+
+      # if: always() is the point: the artifacts that name a hang only exist on the
+      # run that failed or was killed.
+      - name: Upload hang diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: protocol-tests-hang-diagnostics
+          path: TestResults
+          if-no-files-found: ignore

--- a/src/MCServerLauncher.Daemon/Application/Events/OwnedTaskSupervisor.cs
+++ b/src/MCServerLauncher.Daemon/Application/Events/OwnedTaskSupervisor.cs
@@ -132,8 +132,9 @@ internal sealed class OwnedTaskSupervisor(
     private async Task DriveStopAsync(TaskCompletionSource completion)
     {
         // Yield so Schedule()'d work that already signalled "started" can finish installing
-        // CancellationToken registrations before Cancel runs under a loaded thread pool.
-        await Task.Yield();
+        // CancellationToken registrations before Cancel runs under a loaded thread pool. The stop
+        // driver belongs on the pool, not on whatever context called RequestStop().
+        await Task.CompletedTask.ConfigureAwait(ConfigureAwaitOptions.ForceYielding);
 
         try
         {

--- a/src/MCServerLauncher.Daemon/Application/Operations/OperationCoordinator.cs
+++ b/src/MCServerLauncher.Daemon/Application/Operations/OperationCoordinator.cs
@@ -327,9 +327,7 @@ internal sealed class OperationCoordinator : IOperationApplication, IAsyncDispos
         Func<OperationCompletion, Result<Unit, DaemonError>>? terminalCommit,
         CancellationToken shutdownToken)
     {
-        // Scheduled inline under the supervisor's gate from the caller's thread, so yield to the
-        // pool rather than back to whatever context that caller had.
-        await Task.CompletedTask.ConfigureAwait(ConfigureAwaitOptions.ForceYielding);
+        await Task.Yield();
         OperationCompletion completion;
         using var linked = CancellationTokenSource.CreateLinkedTokenSource(
             shutdownToken,

--- a/src/MCServerLauncher.Daemon/Application/Operations/OperationCoordinator.cs
+++ b/src/MCServerLauncher.Daemon/Application/Operations/OperationCoordinator.cs
@@ -327,7 +327,9 @@ internal sealed class OperationCoordinator : IOperationApplication, IAsyncDispos
         Func<OperationCompletion, Result<Unit, DaemonError>>? terminalCommit,
         CancellationToken shutdownToken)
     {
-        await Task.Yield();
+        // Scheduled inline under the supervisor's gate from the caller's thread, so yield to the
+        // pool rather than back to whatever context that caller had.
+        await Task.CompletedTask.ConfigureAwait(ConfigureAwaitOptions.ForceYielding);
         OperationCompletion completion;
         using var linked = CancellationTokenSource.CreateLinkedTokenSource(
             shutdownToken,

--- a/src/MCServerLauncher.Daemon/Management/Communicate/InstanceProcess.cs
+++ b/src/MCServerLauncher.Daemon/Management/Communicate/InstanceProcess.cs
@@ -214,7 +214,7 @@ public class InstanceProcess : DisposableObject
         }
         catch
         {
-            await TerminateAndDrainAsync();
+            await TerminateAndDrainAsync().ConfigureAwait(false);
             throw;
         }
     }
@@ -253,8 +253,9 @@ public class InstanceProcess : DisposableObject
 
     private async Task TransitionAfterStartAsync(InstanceLifecycleSignal signal)
     {
-        // Yield so StartAsync can return while status is still Starting.
-        await Task.Yield();
+        // Yield so StartAsync can return while status is still Starting. The transition runs on the
+        // pool, never on the caller's context.
+        await Task.CompletedTask.ConfigureAwait(ConfigureAwaitOptions.ForceYielding);
         try
         {
             await ApplyLifecycleSignalAsync(signal).ConfigureAwait(false);
@@ -271,7 +272,7 @@ public class InstanceProcess : DisposableObject
         if (completion is null)
         {
             if (_process is not null)
-                await _process.WaitForExitAsync(ct);
+                await _process.WaitForExitAsync(ct).ConfigureAwait(false);
             await AwaitTrackedPublicationsAsync(ct).ConfigureAwait(false);
             return;
         }
@@ -457,7 +458,7 @@ public class InstanceProcess : DisposableObject
         {
             while (true)
             {
-                var line = await reader.ReadLineAsync(CancellationToken.None);
+                var line = await reader.ReadLineAsync(CancellationToken.None).ConfigureAwait(false);
                 if (line is null)
                     return;
 
@@ -873,8 +874,9 @@ public class InstanceProcess : DisposableObject
 
     private static async Task PublishAfterAsync(Task previous, Func<Task> publish, string description)
     {
-        // Never invoke callbacks while the lifecycle-state lock is held.
-        await Task.Yield();
+        // Never invoke callbacks while the lifecycle-state lock is held, and never on the queueing
+        // thread's context: each link resumes on the pool.
+        await Task.CompletedTask.ConfigureAwait(ConfigureAwaitOptions.ForceYielding);
         try
         {
             await previous.ConfigureAwait(false);

--- a/src/MCServerLauncher.Daemon/Plugins/PluginHost.cs
+++ b/src/MCServerLauncher.Daemon/Plugins/PluginHost.cs
@@ -917,7 +917,7 @@ internal sealed class PluginHost
                 .ConfigureAwait(false);
             if (!ReferenceEquals(completed, startTask))
             {
-                ObserveLateStartFault(runtime, startTask);
+                ObserveLateStartOutcome(runtime, startTask);
                 CancelStartAndDisposeLater(runtime, startCancellation);
                 disposeStartCancellation = false;
                 if (ReferenceEquals(completed, startDeadline))
@@ -962,7 +962,7 @@ internal sealed class PluginHost
         catch (OperationCanceledException) when (
             cancellationToken.IsCancellationRequested || runtime.Lifetime.IsCancellationRequested)
         {
-            ObserveLateStartFault(runtime, startTask);
+            ObserveLateStartOutcome(runtime, startTask);
             await FailStartCancellationAsync(runtime, cancellationToken).ConfigureAwait(false);
         }
         catch (Exception exception)
@@ -1014,20 +1014,33 @@ internal sealed class PluginHost
             .ConfigureAwait(false);
     }
 
-    private void ObserveLateStartFault(PluginRuntime runtime, Task startTask)
+    private void ObserveLateStartOutcome(PluginRuntime runtime, Task startTask)
     {
         _ = startTask.ContinueWith(
             static (task, state) =>
             {
                 var (logger, pluginId) = ((ILogger<PluginHost> Logger, string PluginId))state!;
+                if (task.IsCanceled)
+                    return;
+
+                if (task.IsFaulted)
+                {
+                    logger.LogWarning(
+                        task.Exception,
+                        "Plugin {PluginId} StartAsync faulted after startup supervision had already ended.",
+                        pluginId);
+                    return;
+                }
+
+                // The timed-out runtime stays failed; this records that the discard happened, and is
+                // the only host-side signal that a late success was observed at all.
                 logger.LogWarning(
-                    task.Exception,
-                    "Plugin {PluginId} StartAsync faulted after startup supervision had already ended.",
+                    "Plugin {PluginId} StartAsync succeeded after startup supervision had already ended; start_discarded_late.",
                     pluginId);
             },
             (_logger, runtime.Manifest.Identity.Id),
             CancellationToken.None,
-            TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+            TaskContinuationOptions.ExecuteSynchronously,
             TaskScheduler.Default);
     }
 

--- a/src/MCServerLauncher.Daemon/Remote/Event/EventTriggerService.cs
+++ b/src/MCServerLauncher.Daemon/Remote/Event/EventTriggerService.cs
@@ -135,13 +135,13 @@ internal sealed class EventTriggerService : IDisposable, IAsyncDisposable
     internal async Task StopAsync(CancellationToken cancellationToken = default)
     {
         Stop();
-        await DrainSupervisorsAsync(cancellationToken);
+        await DrainSupervisorsAsync(cancellationToken).ConfigureAwait(false);
     }
 
     public async ValueTask DisposeAsync()
     {
         Dispose();
-        await DrainSupervisorsAsync(CancellationToken.None);
+        await DrainSupervisorsAsync(CancellationToken.None).ConfigureAwait(false);
     }
 
     private async Task DrainSupervisorsAsync(CancellationToken cancellationToken)
@@ -154,8 +154,8 @@ internal sealed class EventTriggerService : IDisposable, IAsyncDisposable
 
         foreach (var supervisor in supervisors)
         {
-            await supervisor.DrainAsync(cancellationToken);
-            await supervisor.DisposeAsync();
+            await supervisor.DrainAsync(cancellationToken).ConfigureAwait(false);
+            await supervisor.DisposeAsync().ConfigureAwait(false);
             lock (_lifecycleGate)
                 _retiredSupervisors.Remove(supervisor);
         }
@@ -169,8 +169,9 @@ internal sealed class EventTriggerService : IDisposable, IAsyncDisposable
         try
         {
             var rulesResult = await _application.EventRules.GetEventRulesAsync(
-                new EventRuleQuery(instanceId),
-                cancellationToken);
+                    new EventRuleQuery(instanceId),
+                    cancellationToken)
+                .ConfigureAwait(false);
             if (rulesResult.IsErr(out var rulesError))
             {
                 _logger.LogWarning(
@@ -205,7 +206,7 @@ internal sealed class EventTriggerService : IDisposable, IAsyncDisposable
                 try
                 {
                     if (isTriggered(rule))
-                        await ExecuteActionsAsync(instanceId, rule, cancellationToken);
+                        await ExecuteActionsAsync(instanceId, rule, cancellationToken).ConfigureAwait(false);
                 }
                 catch (Exception exception) when (exception is not OperationCanceledException)
                 {
@@ -253,7 +254,7 @@ internal sealed class EventTriggerService : IDisposable, IAsyncDisposable
 
     private async Task ExecuteActionsAsync(Guid instanceId, EventRule rule, CancellationToken cancellationToken)
     {
-        if (!await EvaluateRulesetsAsync(instanceId, rule, cancellationToken))
+        if (!await EvaluateRulesetsAsync(instanceId, rule, cancellationToken).ConfigureAwait(false))
         {
             _logger.LogDebug("Rulesets did not match for rule '{RuleId}' on instance '{InstanceId}'", rule.Id, instanceId);
             return;
@@ -267,12 +268,13 @@ internal sealed class EventTriggerService : IDisposable, IAsyncDisposable
 
         if (string.Equals(rule.ActionExecutionMode, "Parallel", StringComparison.OrdinalIgnoreCase))
         {
-            await Task.WhenAll(rule.Actions.Select(action => ExecuteSingleActionAsync(instanceId, rule, action, cancellationToken)));
+            await Task.WhenAll(rule.Actions.Select(action => ExecuteSingleActionAsync(instanceId, rule, action, cancellationToken)))
+                .ConfigureAwait(false);
             return;
         }
 
         foreach (var action in rule.Actions)
-            await ExecuteSingleActionAsync(instanceId, rule, action, cancellationToken);
+            await ExecuteSingleActionAsync(instanceId, rule, action, cancellationToken).ConfigureAwait(false);
     }
 
     private async Task<bool> EvaluateRulesetsAsync(Guid instanceId, EventRule rule, CancellationToken cancellationToken)
@@ -281,8 +283,9 @@ internal sealed class EventTriggerService : IDisposable, IAsyncDisposable
             return true;
 
         var reportResult = await _application.Instances.GetInstanceReportAsync(
-            new InstanceReference(instanceId),
-            cancellationToken);
+                new InstanceReference(instanceId),
+                cancellationToken)
+            .ConfigureAwait(false);
         if (reportResult.IsErr(out var reportError))
         {
             _logger.LogWarning(
@@ -337,25 +340,28 @@ internal sealed class EventTriggerService : IDisposable, IAsyncDisposable
                 case SendCommandAction sendCommand:
                     LogActionFailure(
                         await _application.Instances.SendCommandAsync(
-                            new InstanceCommandRequest(instanceId, sendCommand.Command),
-                            cancellationToken),
+                                new InstanceCommandRequest(instanceId, sendCommand.Command),
+                                cancellationToken)
+                            .ConfigureAwait(false),
                         instanceId,
                         rule.Id,
                         sendCommand.Type);
                     break;
                 case ChangeInstanceStatusAction changeStatus:
-                    await ExecuteStatusActionAsync(instanceId, rule.Id, changeStatus.Action, cancellationToken);
+                    await ExecuteStatusActionAsync(instanceId, rule.Id, changeStatus.Action, cancellationToken)
+                        .ConfigureAwait(false);
                     break;
                 case SendNotificationAction sendNotification:
                     await _domainEvents.PublishAsync(
-                        new ClientNotificationDomainEvent(
-                            sendNotification.Title,
-                            sendNotification.Message,
-                            sendNotification.Severity,
-                            instanceId,
-                            rule.Id,
-                            DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()),
-                        cancellationToken);
+                            new ClientNotificationDomainEvent(
+                                sendNotification.Title,
+                                sendNotification.Message,
+                                sendNotification.Severity,
+                                instanceId,
+                                rule.Id,
+                                DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()),
+                            cancellationToken)
+                        .ConfigureAwait(false);
                     break;
                 default:
                     _logger.LogWarning(
@@ -382,34 +388,39 @@ internal sealed class EventTriggerService : IDisposable, IAsyncDisposable
         {
             case "start":
                 LogActionFailure(
-                    await _application.Instances.StartInstanceAsync(new InstanceReference(instanceId), cancellationToken),
+                    await _application.Instances.StartInstanceAsync(new InstanceReference(instanceId), cancellationToken)
+                        .ConfigureAwait(false),
                     instanceId,
                     ruleId,
                     action);
                 break;
             case "stop":
                 LogActionFailure(
-                    await _application.Instances.StopInstanceAsync(new InstanceReference(instanceId), cancellationToken),
+                    await _application.Instances.StopInstanceAsync(new InstanceReference(instanceId), cancellationToken)
+                        .ConfigureAwait(false),
                     instanceId,
                     ruleId,
                     action);
                 break;
             case "kill":
                 LogActionFailure(
-                    await _application.Instances.HaltInstanceAsync(new InstanceReference(instanceId), cancellationToken),
+                    await _application.Instances.HaltInstanceAsync(new InstanceReference(instanceId), cancellationToken)
+                        .ConfigureAwait(false),
                     instanceId,
                     ruleId,
                     action);
                 break;
             case "restart":
                 LogActionFailure(
-                    await _application.Instances.StopInstanceAsync(new InstanceReference(instanceId), cancellationToken),
+                    await _application.Instances.StopInstanceAsync(new InstanceReference(instanceId), cancellationToken)
+                        .ConfigureAwait(false),
                     instanceId,
                     ruleId,
                     "restart.stop");
-                await Task.Delay(_restartDelay, cancellationToken);
+                await Task.Delay(_restartDelay, cancellationToken).ConfigureAwait(false);
                 LogActionFailure(
-                    await _application.Instances.StartInstanceAsync(new InstanceReference(instanceId), cancellationToken),
+                    await _application.Instances.StartInstanceAsync(new InstanceReference(instanceId), cancellationToken)
+                        .ConfigureAwait(false),
                     instanceId,
                     ruleId,
                     "restart.start");

--- a/src/MCServerLauncher.Daemon/Remote/Rpc/Transport/V2ConnectionOwner.cs
+++ b/src/MCServerLauncher.Daemon/Remote/Rpc/Transport/V2ConnectionOwner.cs
@@ -235,14 +235,14 @@ internal sealed class V2ConnectionOwner : ICompiledProtocolPermissionView, IAsyn
             LaunchClose(closePlan);
         }
 
-        await AwaitShutdownAsync();
+        await AwaitShutdownAsync().ConfigureAwait(false);
     }
 
     private async Task PumpAsync()
     {
         try
         {
-            await foreach (var message in _outbound.Reader.ReadAllAsync(_connectionToken))
+            await foreach (var message in _outbound.Reader.ReadAllAsync(_connectionToken).ConfigureAwait(false))
             {
                 if (IsNonGracefulStopRequested())
                     break;
@@ -263,9 +263,10 @@ internal sealed class V2ConnectionOwner : ICompiledProtocolPermissionView, IAsyn
                     try
                     {
                         await sendTask.WaitAsync(
-                            FrameSendTimeout,
-                            _timeProvider,
-                            _connectionToken);
+                                FrameSendTimeout,
+                                _timeProvider,
+                                _connectionToken)
+                            .ConfigureAwait(false);
                     }
                     catch (TimeoutException)
                     {
@@ -337,7 +338,8 @@ internal sealed class V2ConnectionOwner : ICompiledProtocolPermissionView, IAsyn
     private async Task CloseCoreAsync(ClosePlan closePlan)
     {
         // A producer that detects backpressure only schedules shutdown; it never runs cleanup or close callbacks inline.
-        await Task.Yield();
+        // Yield to the pool rather than the caller's context: a producer thread must not host the close chain.
+        await Task.CompletedTask.ConfigureAwait(ConfigureAwaitOptions.ForceYielding);
 
         List<Exception>? failures = null;
         try
@@ -347,20 +349,20 @@ internal sealed class V2ConnectionOwner : ICompiledProtocolPermissionView, IAsyn
 
             try
             {
-                await _connectionLifetime.CancelAsync();
+                await _connectionLifetime.CancelAsync().ConfigureAwait(false);
             }
             catch (Exception exception)
             {
                 (failures ??= []).Add(exception);
             }
 
-            await _pumpCompletion.Task;
+            await _pumpCompletion.Task.ConfigureAwait(false);
 
             foreach (var cleanup in closePlan.Cleanups)
             {
                 try
                 {
-                    await cleanup.CleanupAsync(CancellationToken.None);
+                    await cleanup.CleanupAsync(CancellationToken.None).ConfigureAwait(false);
                 }
                 catch (Exception exception)
                 {
@@ -383,7 +385,8 @@ internal sealed class V2ConnectionOwner : ICompiledProtocolPermissionView, IAsyn
 
                 try
                 {
-                    await closeTask.WaitAsync(FrameSendTimeout, _timeProvider, CancellationToken.None);
+                    await closeTask.WaitAsync(FrameSendTimeout, _timeProvider, CancellationToken.None)
+                        .ConfigureAwait(false);
                 }
                 catch (TimeoutException)
                 {
@@ -410,8 +413,8 @@ internal sealed class V2ConnectionOwner : ICompiledProtocolPermissionView, IAsyn
 
     private async Task AwaitShutdownAsync()
     {
-        await _pumpCompletion.Task;
-        await _closeCompletion.Task;
+        await _pumpCompletion.Task.ConfigureAwait(false);
+        await _closeCompletion.Task.ConfigureAwait(false);
     }
 
     private static void ObserveAbandonedSend(Task sendTask)

--- a/src/MCServerLauncher.DaemonClient/Connection/V2/V2ClientConnectionOwner.cs
+++ b/src/MCServerLauncher.DaemonClient/Connection/V2/V2ClientConnectionOwner.cs
@@ -208,7 +208,9 @@ internal sealed class V2ClientConnectionOwner : IAsyncDisposable
 
     private async Task RunLifecycleAsync()
     {
-        await Task.Yield();
+        // Started under _gate from ConnectAsync: hand off to the pool so the lifecycle worker never
+        // inherits the connecting caller's context.
+        await Task.CompletedTask.ConfigureAwait(ConfigureAwaitOptions.ForceYielding);
         try
         {
             while (!_lifetimeCancellation.IsCancellationRequested)

--- a/tests/Fixtures/Plugins/StartHanging/StartHangingPlugins.cs
+++ b/tests/Fixtures/Plugins/StartHanging/StartHangingPlugins.cs
@@ -188,7 +188,21 @@ public sealed class DelayedRegisteredSuccessPlugin : IGeneratedDaemonPluginAdapt
         _ = cancellationToken;
         // Intentionally ignores cancellation and must remain incomplete past the host deadline so
         // late success cannot race past Task.Delay supervision under CI load.
-        await Task.Delay(Timeout.InfiniteTimeSpan, CancellationToken.None);
+        var releasePath = Environment.GetEnvironmentVariable("MCSL_PLUGIN_LATE_SUCCESS_RELEASE_PATH");
+        if (string.IsNullOrWhiteSpace(releasePath))
+        {
+            await Task.Delay(Timeout.InfiniteTimeSpan, CancellationToken.None);
+            return PluginResult.Ok();
+        }
+
+        // A test that wants to exercise the late-success leg opens this gate once the host has
+        // already timed the plugin out, so the success is genuinely late rather than racing.
+        while (!File.Exists(releasePath))
+            await Task.Delay(TimeSpan.FromMilliseconds(10), CancellationToken.None);
+
+        var completedPath = Environment.GetEnvironmentVariable("MCSL_PLUGIN_LATE_SUCCESS_COMPLETED_PATH");
+        if (!string.IsNullOrWhiteSpace(completedPath))
+            File.WriteAllText(completedPath, string.Empty);
         return PluginResult.Ok();
     }
 

--- a/tests/Fixtures/Plugins/StartHanging/StartHangingPlugins.cs
+++ b/tests/Fixtures/Plugins/StartHanging/StartHangingPlugins.cs
@@ -196,13 +196,11 @@ public sealed class DelayedRegisteredSuccessPlugin : IGeneratedDaemonPluginAdapt
         }
 
         // A test that wants to exercise the late-success leg opens this gate once the host has
-        // already timed the plugin out, so the success is genuinely late rather than racing.
+        // already timed the plugin out, so the success is genuinely late rather than racing. The
+        // test waits on the host's own late-completion log, not on this method returning.
         while (!File.Exists(releasePath))
             await Task.Delay(TimeSpan.FromMilliseconds(10), CancellationToken.None);
 
-        var completedPath = Environment.GetEnvironmentVariable("MCSL_PLUGIN_LATE_SUCCESS_COMPLETED_PATH");
-        if (!string.IsNullOrWhiteSpace(completedPath))
-            File.WriteAllText(completedPath, string.Empty);
         return PluginResult.Ok();
     }
 

--- a/tests/MCServerLauncher.ProtocolTests/Application/LocalInstanceApplicationTests.cs
+++ b/tests/MCServerLauncher.ProtocolTests/Application/LocalInstanceApplicationTests.cs
@@ -10,9 +10,9 @@ using MCServerLauncher.Daemon.Management.Communicate;
 using MCServerLauncher.Daemon.Management.Factory;
 using MCServerLauncher.Daemon.Storage;
 using MCServerLauncher.Daemon.Utils;
+using MCServerLauncher.ProtocolTests.Helpers;
 using RustyOptions;
 using LegacyInstanceReport = MCServerLauncher.Common.ProtoType.Instance.InstanceReport;
-using MCServerLauncher.ProtocolTests.Helpers;
 
 namespace MCServerLauncher.ProtocolTests;
 

--- a/tests/MCServerLauncher.ProtocolTests/Application/LocalInstanceApplicationTests.cs
+++ b/tests/MCServerLauncher.ProtocolTests/Application/LocalInstanceApplicationTests.cs
@@ -12,6 +12,7 @@ using MCServerLauncher.Daemon.Storage;
 using MCServerLauncher.Daemon.Utils;
 using RustyOptions;
 using LegacyInstanceReport = MCServerLauncher.Common.ProtoType.Instance.InstanceReport;
+using MCServerLauncher.ProtocolTests.Helpers;
 
 namespace MCServerLauncher.ProtocolTests;
 
@@ -1622,7 +1623,8 @@ public sealed class LocalInstanceApplicationTests
         manager.ReplaceInstance(config.Uuid, instance);
         instance.BlockNextConfigRead();
 
-        var statusTask = Task.Run(() => instance.RaiseStatusChangedAsync(InstanceStatus.Running));
+        // The status callback blocks on a gated Config read; keep that off the ThreadPool too.
+        var statusTask = OffPool.RunAsync(() => instance.RaiseStatusChangedAsync(InstanceStatus.Running));
         Task<bool> removeTask;
         try
         {

--- a/tests/MCServerLauncher.ProtocolTests/Application/MonitoringSamplerTests.cs
+++ b/tests/MCServerLauncher.ProtocolTests/Application/MonitoringSamplerTests.cs
@@ -18,6 +18,7 @@ using InstanceFactoryConfiguration = MCServerLauncher.Common.Contracts.Instances
 using InstanceSettingsResult = MCServerLauncher.Common.Contracts.Instances.InstanceSettingsResult;
 using UpdateInstanceSettingsRequest = MCServerLauncher.Common.Contracts.Instances.UpdateInstanceSettingsRequest;
 using UpdateInstanceSettingsResult = MCServerLauncher.Common.Contracts.Instances.UpdateInstanceSettingsResult;
+using MCServerLauncher.ProtocolTests.Helpers;
 
 namespace MCServerLauncher.ProtocolTests;
 
@@ -336,7 +337,7 @@ public sealed class MonitoringSamplerTests
         // and turns a 40ms test into a job that never finishes. Pacing also widens the window under
         // test: more events accumulate between snapshots, so each drain moves more of them, which is
         // exactly the interval a producer used to misread.
-        var consumer = Task.Run(() =>
+        var consumer = OffPool.Run(() =>
         {
             events.Snapshot();
             snapshotting.TrySetResult();

--- a/tests/MCServerLauncher.ProtocolTests/Application/MonitoringSamplerTests.cs
+++ b/tests/MCServerLauncher.ProtocolTests/Application/MonitoringSamplerTests.cs
@@ -12,13 +12,13 @@ using MCServerLauncher.Daemon.ApplicationCore.Monitoring;
 using MCServerLauncher.Daemon.Management;
 using MCServerLauncher.Daemon.Management.Communicate;
 using MCServerLauncher.Daemon.Utils.LazyCell;
+using MCServerLauncher.ProtocolTests.Helpers;
 using RustyOptions;
 using ContractInstanceConfiguration = MCServerLauncher.Common.Contracts.Instances.InstanceConfiguration;
 using InstanceFactoryConfiguration = MCServerLauncher.Common.Contracts.Instances.InstanceFactoryConfiguration;
 using InstanceSettingsResult = MCServerLauncher.Common.Contracts.Instances.InstanceSettingsResult;
 using UpdateInstanceSettingsRequest = MCServerLauncher.Common.Contracts.Instances.UpdateInstanceSettingsRequest;
 using UpdateInstanceSettingsResult = MCServerLauncher.Common.Contracts.Instances.UpdateInstanceSettingsResult;
-using MCServerLauncher.ProtocolTests.Helpers;
 
 namespace MCServerLauncher.ProtocolTests;
 

--- a/tests/MCServerLauncher.ProtocolTests/Application/ProvisioningPlanKernelTests.cs
+++ b/tests/MCServerLauncher.ProtocolTests/Application/ProvisioningPlanKernelTests.cs
@@ -8,6 +8,7 @@ using MCServerLauncher.Daemon.ApplicationCore.Operations;
 using MCServerLauncher.Daemon.ApplicationCore.Provisioning;
 using Microsoft.Extensions.Logging;
 using RustyOptions;
+using MCServerLauncher.ProtocolTests.Helpers;
 
 namespace MCServerLauncher.ProtocolTests;
 
@@ -733,11 +734,12 @@ public sealed class ProvisioningPlanKernelTests
             var expiredAt = plan!.ExpiresAt + TimeSpan.FromSeconds(1);
 
             var expiryReadEntered = time.ArmNextRead(expiredAt);
-            var getTask = Task.Run(() => kernel.Get(plan.PlanId));
+            // Both racers reach BlockingTimeProvider.GetUtcNow, which blocks its caller by design.
+            var getTask = OffPool.Run(() => kernel.Get(plan.PlanId));
             await expiryReadEntered.WaitAsync(TimeSpan.FromSeconds(3));
 
             var beginInvoked = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-            var beginTask = Task.Run(() =>
+            var beginTask = OffPool.Run(() =>
             {
                 beginInvoked.TrySetResult();
                 return kernel.TryBeginExecute(plan.PlanId, "owner-a");

--- a/tests/MCServerLauncher.ProtocolTests/Application/ProvisioningPlanKernelTests.cs
+++ b/tests/MCServerLauncher.ProtocolTests/Application/ProvisioningPlanKernelTests.cs
@@ -6,9 +6,9 @@ using MCServerLauncher.Common.ProtoType.Instance;
 using MCServerLauncher.Daemon.API.Errors;
 using MCServerLauncher.Daemon.ApplicationCore.Operations;
 using MCServerLauncher.Daemon.ApplicationCore.Provisioning;
+using MCServerLauncher.ProtocolTests.Helpers;
 using Microsoft.Extensions.Logging;
 using RustyOptions;
-using MCServerLauncher.ProtocolTests.Helpers;
 
 namespace MCServerLauncher.ProtocolTests;
 

--- a/tests/MCServerLauncher.ProtocolTests/DaemonClient/V2/RemoteInstanceCatalogMirrorTests.cs
+++ b/tests/MCServerLauncher.ProtocolTests/DaemonClient/V2/RemoteInstanceCatalogMirrorTests.cs
@@ -6,6 +6,7 @@ using MCServerLauncher.Common.Contracts.Protocol;
 using MCServerLauncher.Common.ProtoType.Instance;
 using MCServerLauncher.Daemon.API.State;
 using MCServerLauncher.DaemonClient.State;
+using MCServerLauncher.ProtocolTests.Helpers;
 
 namespace MCServerLauncher.ProtocolTests.DaemonClient.V2;
 
@@ -577,28 +578,27 @@ public sealed class RemoteInstanceCatalogMirrorTests
     }
 
     [Fact]
-    public void BeginReceiveFullAndCloseRace_OldGenerationNeverPublishesAndCloseIsTerminal()
+    public async Task BeginReceiveFullAndCloseRace_OldGenerationNeverPublishesAndCloseIsTerminal()
     {
         var mirror = ReadyMirror(out var oldGeneration, 0, Item(FirstId, "stable"));
         Assert.Equal(RemoteInstanceCatalogTransition.NeedsResync,
             mirror.ReceiveChange(oldGeneration, Upsert(2, FirstId, "force-resync")));
         var before = mirror.Current;
         const int participantCount = 4;
-        using var ready = new CountdownEvent(participantCount);
+        using var ready = new SemaphoreSlim(0);
         using var start = new ManualResetEventSlim();
-        using var finished = new CountdownEvent(participantCount);
         var failures = new ConcurrentQueue<Exception>();
         var transitions = new ConcurrentQueue<RemoteInstanceCatalogTransition>();
         long newGeneration = 0;
         var beginClosed = 0;
 
-        Thread CreateParticipant(ThreadStart operation)
+        Task CreateParticipant(Action operation)
         {
-            return new Thread(() =>
+            return OffPool.Run(() =>
             {
                 try
                 {
-                    ready.Signal();
+                    ready.Release();
                     if (!start.Wait(TimeSpan.FromSeconds(10)))
                         throw new TimeoutException("The catalog race start gate was not released.");
                     operation();
@@ -607,18 +607,10 @@ public sealed class RemoteInstanceCatalogMirrorTests
                 {
                     failures.Enqueue(exception);
                 }
-                finally
-                {
-                    finished.Signal();
-                }
-            })
-            {
-                IsBackground = true,
-                Name = "RemoteInstanceCatalogMirror race participant"
-            };
+            });
         }
 
-        var threads = new[]
+        var participants = new[]
         {
             CreateParticipant(() =>
             {
@@ -639,25 +631,25 @@ public sealed class RemoteInstanceCatalogMirrorTests
         };
 
         var allFinished = false;
-        var allJoined = false;
         try
         {
-            foreach (var thread in threads)
-                thread.Start();
+            for (var poised = 0; poised < participantCount; poised++)
+            {
+                Assert.True(
+                    await ready.WaitAsync(TimeSpan.FromSeconds(10)),
+                    "Race participants did not become ready.");
+            }
 
-            Assert.True(ready.Wait(TimeSpan.FromSeconds(10)), "Race participants did not become ready.");
             start.Set();
-            allFinished = finished.Wait(TimeSpan.FromSeconds(10));
+            allFinished = await AllCompletedAsync(participants, TimeSpan.FromSeconds(10));
         }
         finally
         {
             start.Set();
-            allFinished = finished.Wait(TimeSpan.FromSeconds(10)) || allFinished;
-            allJoined = JoinAll(threads, TimeSpan.FromSeconds(2));
+            allFinished = await AllCompletedAsync(participants, TimeSpan.FromSeconds(10)) || allFinished;
         }
 
         Assert.True(allFinished, "Race participants did not finish within the bounded timeout.");
-        Assert.True(allJoined, "Race participant threads did not terminate within the bounded timeout.");
         Assert.Empty(failures);
         Assert.Equal(2, transitions.Count);
         Assert.All(transitions, transition => Assert.Contains(
@@ -696,7 +688,7 @@ public sealed class RemoteInstanceCatalogMirrorTests
     }
 
     [Fact]
-    public void ConcurrentReadersWithFullDeltaAndReconnect_NeverObserveTornCatalogs()
+    public async Task ConcurrentReadersWithFullDeltaAndReconnect_NeverObserveTornCatalogs()
     {
         const int readerCount = 32;
         const int cycles = 80;
@@ -704,26 +696,25 @@ public sealed class RemoteInstanceCatalogMirrorTests
             0,
             Item(FirstId, Marker(0), Marker(0)),
             Item(SecondId, Marker(0), Marker(0)));
-        using var ready = new CountdownEvent(readerCount);
+        using var ready = new SemaphoreSlim(0);
         using var start = new ManualResetEventSlim();
-        using var initialRead = new CountdownEvent(readerCount);
+        using var initialRead = new SemaphoreSlim(0);
         using var stop = new ManualResetEventSlim();
-        using var finished = new CountdownEvent(readerCount);
         var failures = new ConcurrentQueue<Exception>();
         var observedPublicationChange = 0;
-        var readers = Enumerable.Range(0, readerCount).Select(readerIndex => new Thread(() =>
+        var readers = Enumerable.Range(0, readerCount).Select(readerIndex => OffPool.Run(() =>
         {
             var initialReadSignaled = false;
             try
             {
-                ready.Signal();
+                ready.Release();
                 if (!start.Wait(TimeSpan.FromSeconds(10)))
                     throw new TimeoutException($"Reader {readerIndex} did not receive the start signal.");
 
                 var startingHandle = mirror.Current;
                 var startingVersion = startingHandle.Version;
                 AssertCompleteHandle(startingHandle);
-                initialRead.Signal();
+                initialRead.Release();
                 initialReadSignaled = true;
                 var observed = false;
                 while (!stop.IsSet)
@@ -744,34 +735,24 @@ public sealed class RemoteInstanceCatalogMirrorTests
             finally
             {
                 if (!initialReadSignaled)
-                {
-                    try
-                    {
-                        initialRead.Signal();
-                    }
-                    catch (InvalidOperationException)
-                    {
-                    }
-                }
-                finished.Signal();
+                    initialRead.Release();
             }
-        })
-        {
-            IsBackground = true,
-            Name = $"RemoteInstanceCatalogMirror reader {readerIndex}"
-        }).ToArray();
+        })).ToArray();
 
         Exception? writerFailure = null;
         var allFinished = false;
-        var allJoined = false;
         try
         {
-            foreach (var reader in readers)
-                reader.Start();
+            for (var poised = 0; poised < readerCount; poised++)
+                Assert.True(await ready.WaitAsync(TimeSpan.FromSeconds(10)), "Readers did not become ready.");
 
-            Assert.True(ready.Wait(TimeSpan.FromSeconds(10)), "Readers did not become ready.");
             start.Set();
-            Assert.True(initialRead.Wait(TimeSpan.FromSeconds(10)), "Readers did not capture the initial publication.");
+            for (var read = 0; read < readerCount; read++)
+            {
+                Assert.True(
+                    await initialRead.WaitAsync(TimeSpan.FromSeconds(10)),
+                    "Readers did not capture the initial publication.");
+            }
 
             for (var cycle = 1; cycle <= cycles; cycle++)
             {
@@ -792,7 +773,7 @@ public sealed class RemoteInstanceCatalogMirrorTests
             }
 
             Assert.True(
-                SpinWait.SpinUntil(
+                await SpinUntilAsync(
                     () => Volatile.Read(ref observedPublicationChange) == readerCount,
                     TimeSpan.FromSeconds(10)),
                 "Every reader must overlap the writer and observe a publication change.");
@@ -805,12 +786,10 @@ public sealed class RemoteInstanceCatalogMirrorTests
         {
             start.Set();
             stop.Set();
-            allFinished = finished.Wait(TimeSpan.FromSeconds(10));
-            allJoined = JoinAll(readers, TimeSpan.FromSeconds(2));
+            allFinished = await AllCompletedAsync(readers, TimeSpan.FromSeconds(10));
         }
 
         Assert.True(allFinished, "Reader threads did not finish within the bounded timeout.");
-        Assert.True(allJoined, "Reader threads did not terminate within the bounded timeout.");
         if (writerFailure is not null)
             ExceptionDispatchInfo.Capture(writerFailure).Throw();
         Assert.Empty(failures);
@@ -863,16 +842,30 @@ public sealed class RemoteInstanceCatalogMirrorTests
         }
     }
 
-    private static bool JoinAll(IEnumerable<Thread> threads, TimeSpan timeout)
+    private static async Task<bool> AllCompletedAsync(Task[] workers, TimeSpan timeout)
     {
-        var stopwatch = Stopwatch.StartNew();
-        var allJoined = true;
-        foreach (var thread in threads)
+        try
         {
-            var remaining = timeout - stopwatch.Elapsed;
-            allJoined &= remaining > TimeSpan.Zero && thread.Join(remaining);
+            await Task.WhenAll(workers).WaitAsync(timeout);
+            return true;
         }
-        return allJoined;
+        catch (TimeoutException)
+        {
+            return false;
+        }
+    }
+
+    private static async Task<bool> SpinUntilAsync(Func<bool> condition, TimeSpan timeout)
+    {
+        var deadline = Stopwatch.StartNew();
+        while (!condition())
+        {
+            if (deadline.Elapsed > timeout)
+                return false;
+            await Task.Delay(1).ConfigureAwait(false);
+        }
+
+        return true;
     }
 
     private static InstanceCatalogResult Full(long version, params InstanceCatalogItem[] items) =>

--- a/tests/MCServerLauncher.ProtocolTests/DaemonClient/V2/V2ClientConnectionCoordinatorTests.cs
+++ b/tests/MCServerLauncher.ProtocolTests/DaemonClient/V2/V2ClientConnectionCoordinatorTests.cs
@@ -6,6 +6,7 @@ using MCServerLauncher.Common.Contracts.Protocol;
 using MCServerLauncher.Daemon.API.Errors;
 using MCServerLauncher.DaemonClient.Connection.V2;
 using MCServerLauncher.DaemonClient.State;
+using MCServerLauncher.ProtocolTests.Helpers;
 
 namespace MCServerLauncher.ProtocolTests.DaemonClient.V2;
 
@@ -409,10 +410,10 @@ public sealed class V2ClientConnectionCoordinatorTests : IAsyncLifetime
         await MakeReadyAsync(coordinator, transport, Catalog(1, Item("one")));
         coordinator.Core.RouteText(CatalogEvent(3, "three"));
         var refetch = await transport.NextAsync();
-        using var workersReady = new CountdownEvent(3);
+        using var workersReady = new SemaphoreSlim(0);
         using var release = new ManualResetEventSlim();
         var failures = new ConcurrentQueue<Exception>();
-        var threads = new[]
+        var workers = new[]
         {
             DedicatedWorker(() => coordinator.Core.RouteText(Success(refetch, Catalog(2, Item("two")))), workersReady, release, failures),
             DedicatedWorker(() => coordinator.Core.RouteText(CatalogEvent(3, "three")), workersReady, release, failures),
@@ -421,23 +422,17 @@ public sealed class V2ClientConnectionCoordinatorTests : IAsyncLifetime
 
         try
         {
-            foreach (var thread in threads)
-                thread.Start();
+            for (var poised = 0; poised < workers.Length; poised++)
+                Assert.True(await workersReady.WaitAsync(Timeout));
 
-            Assert.True(workersReady.Wait(Timeout));
             release.Set();
-            Assert.All(threads, thread => Assert.True(thread.Join(Timeout)));
+            await Task.WhenAll(workers).WaitAsync(Timeout);
             await coordinator.CloseAsync().WaitAsync(Timeout);
         }
         finally
         {
             release.Set();
-            foreach (var thread in threads)
-            {
-                if (thread.IsAlive)
-                    thread.Join(Timeout);
-            }
-
+            await Task.WhenAll(workers).WaitAsync(Timeout);
             await coordinator.CloseAsync().WaitAsync(Timeout);
         }
 
@@ -614,17 +609,17 @@ public sealed class V2ClientConnectionCoordinatorTests : IAsyncLifetime
 
     private static byte[] Utf8(string value) => Encoding.UTF8.GetBytes(value);
 
-    private static Thread DedicatedWorker(
+    private static Task DedicatedWorker(
         Action action,
-        CountdownEvent ready,
+        SemaphoreSlim ready,
         ManualResetEventSlim release,
         ConcurrentQueue<Exception> failures)
     {
-        return new Thread(() =>
+        return OffPool.Run(() =>
         {
             try
             {
-                ready.Signal();
+                ready.Release();
                 if (!release.Wait(Timeout))
                     throw new TimeoutException("The concurrent coordinator test was not released.");
 
@@ -634,10 +629,7 @@ public sealed class V2ClientConnectionCoordinatorTests : IAsyncLifetime
             {
                 failures.Enqueue(exception);
             }
-        })
-        {
-            IsBackground = true
-        };
+        });
     }
 
     private sealed record SentRequest(string Method, string IdJson, string Json);

--- a/tests/MCServerLauncher.ProtocolTests/DaemonClient/V2/V2ClientConnectionCoreTests.cs
+++ b/tests/MCServerLauncher.ProtocolTests/DaemonClient/V2/V2ClientConnectionCoreTests.cs
@@ -6,6 +6,7 @@ using MCServerLauncher.Daemon.API.Errors;
 using MCServerLauncher.Daemon.API.Protocol;
 using MCServerLauncher.DaemonClient.Connection.V2;
 using MCServerLauncher.DaemonClient.Application;
+using MCServerLauncher.ProtocolTests.Helpers;
 using RustyOptions;
 
 namespace MCServerLauncher.ProtocolTests.DaemonClient.V2;
@@ -176,16 +177,15 @@ public sealed class V2ClientConnectionCoreTests
         var core = new V2ClientConnectionCore(transport, TimeProvider.System, Timeout);
         using var barrier = new Barrier(2);
         Result<PingResult, DaemonError>? raced = null;
-        var worker = new Thread(() =>
+        var worker = OffPool.Run(() =>
         {
-            barrier.SignalAndWait();
+            Assert.True(barrier.SignalAndWait(Timeout));
             raced = core.InvokeAsync(Descriptor<EmptyRequest, PingResult>("mcsl.daemon.ping"), new EmptyRequest())
                 .GetAwaiter().GetResult();
         });
-        worker.Start();
         core.Close();
-        barrier.SignalAndWait();
-        worker.Join();
+        Assert.True(barrier.SignalAndWait(Timeout));
+        await worker.WaitAsync(Timeout);
         var results = new List<Result<PingResult, DaemonError>> { raced!.Value };
         for (var index = 0; index < 32; index++)
         {
@@ -202,10 +202,10 @@ public sealed class V2ClientConnectionCoreTests
         var transport = new SynchronouslyEnteringTransport();
         var core = new V2ClientConnectionCore(transport, TimeProvider.System, Timeout,
             () => JsonRpcRequestId.FromString(Guid.NewGuid().ToString("D")));
-        var admitted = Task.Run(() => core.InvokeAsync(
+        var admitted = OffPool.RunAsync(() => core.InvokeAsync(
             Descriptor<EmptyRequest, PingResult>("mcsl.daemon.ping"), new EmptyRequest()));
-        Assert.True(transport.Entered.Wait(TimeSpan.FromSeconds(5)));
-        var close = Task.Run(core.Close);
+        await transport.Entered.WaitAsync(TimeSpan.FromSeconds(5));
+        var close = OffPool.Run(core.Close);
         Assert.False(close.IsCompleted);
 
         transport.ReleaseReturn.Set();
@@ -507,12 +507,12 @@ public sealed class V2ClientConnectionCoreTests
         var session = DownloadSession();
         Assert.True(core.TryRegisterDownloadSession(session, out _));
 
-        var invoke = Task.Run(() => core.ReadDownloadChunkAsync(
+        var invoke = OffPool.RunAsync(() => core.ReadDownloadChunkAsync(
             new DownloadChunkRequest(session.SessionId, 0, 1),
             CancellationToken.None));
         await transport.Entered.WaitAsync(TimeSpan.FromSeconds(5));
 
-        await Task.Run(core.Close).WaitAsync(TimeSpan.FromSeconds(5));
+        await OffPool.Run(core.Close).WaitAsync(TimeSpan.FromSeconds(5));
         await transport.TokenCanceled.WaitAsync(TimeSpan.FromSeconds(5));
         var read = await invoke.WaitAsync(TimeSpan.FromSeconds(5));
         Assert.True(read.IsErr(out var error));
@@ -712,7 +712,7 @@ public sealed class V2ClientConnectionCoreTests
         var transport = new CancellationBlockingBinaryTransport();
         var core = new V2ClientConnectionCore(transport, TimeProvider.System, Timeout);
         var session = Guid.NewGuid();
-        var upload = Task.Run(() => core.SendUploadChunkAsync(
+        var upload = OffPool.RunAsync(() => core.SendUploadChunkAsync(
             new UploadChunkRequest(session, 0, ImmutableArray.Create<byte>(1)),
             1,
             CancellationToken.None));
@@ -720,7 +720,7 @@ public sealed class V2ClientConnectionCoreTests
 
         try
         {
-            var close = Task.Run(core.Close);
+            var close = OffPool.Run(core.Close);
             await close.WaitAsync(TimeSpan.FromSeconds(5));
             await transport.TokenCanceled.WaitAsync(TimeSpan.FromSeconds(5));
         }
@@ -744,13 +744,13 @@ public sealed class V2ClientConnectionCoreTests
     {
         var transport = new CloseBlockingCancellationBinaryTransport();
         var core = new V2ClientConnectionCore(transport, TimeProvider.System, Timeout);
-        var upload = Task.Run(() => core.SendUploadChunkAsync(
+        var upload = OffPool.RunAsync(() => core.SendUploadChunkAsync(
             new UploadChunkRequest(Guid.NewGuid(), 0, ImmutableArray.Create<byte>(1)),
             1,
             CancellationToken.None));
         await transport.Entered.WaitAsync(TimeSpan.FromSeconds(5));
 
-        var close = Task.Run(core.Close);
+        var close = OffPool.Run(core.Close);
         try
         {
             await transport.CloseBlocked.WaitAsync(TimeSpan.FromSeconds(5));
@@ -1071,7 +1071,7 @@ public sealed class V2ClientConnectionCoreTests
                 throw new TimeoutException("The reentrant close callback was not released.");
         };
 
-        var winningClose = Task.Run(core.Close);
+        var winningClose = OffPool.Run(core.Close);
         await callbackEntered.Task.WaitAsync(TimeSpan.FromSeconds(5));
         core.Close();
         Assert.False(core.Closed.IsCompleted);
@@ -1314,7 +1314,8 @@ public sealed class V2ClientConnectionCoreTests
     {
         private readonly TaskCompletionSource _completion = new(TaskCreationOptions.RunContinuationsAsynchronously);
         private readonly TaskCompletionSource _tokenCanceled = new(TaskCreationOptions.RunContinuationsAsynchronously);
-        public ManualResetEventSlim Entered { get; } = new();
+        private readonly TaskCompletionSource _entered = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public Task Entered => _entered.Task;
         public ManualResetEventSlim ReleaseReturn { get; } = new();
         public Task TokenCanceled => _tokenCanceled.Task;
         public int SendCount;
@@ -1323,7 +1324,7 @@ public sealed class V2ClientConnectionCoreTests
         {
             Interlocked.Increment(ref SendCount);
             cancellationToken.Register(() => _tokenCanceled.TrySetResult());
-            Entered.Set();
+            _entered.TrySetResult();
             if (!ReleaseReturn.Wait(TimeSpan.FromSeconds(5))) throw new TimeoutException();
             return new(_completion.Task);
         }

--- a/tests/MCServerLauncher.ProtocolTests/DaemonClient/V2/V2ClientConnectionOwnerTests.cs
+++ b/tests/MCServerLauncher.ProtocolTests/DaemonClient/V2/V2ClientConnectionOwnerTests.cs
@@ -176,18 +176,18 @@ public sealed class V2ClientConnectionOwnerTests
     {
         var factory = new ControlledSessionFactory();
         await using var owner = Owner(factory);
-        using var releaseFirstObserver = new ManualResetEventSlim();
+        var releaseFirstObserver = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var firstObserverEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var secondObserverStates = new ConcurrentQueue<DaemonConnectionState>();
         var readyObserved = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        owner.StateChanged += state =>
+        owner.StateChanged += async state =>
         {
             if (state != DaemonConnectionState.Connecting)
-                return Task.CompletedTask;
+                return;
             firstObserverEntered.TrySetResult();
-            if (!releaseFirstObserver.Wait(Timeout))
-                throw new TimeoutException("The first state observer was not released.");
-            return Task.CompletedTask;
+            // Hold the drain asynchronously: a suspended observer must delay later observers exactly
+            // as a blocked one would, without parking the drain worker.
+            await releaseFirstObserver.Task.WaitAsync(Timeout);
         };
         owner.StateChanged += state =>
         {
@@ -206,7 +206,7 @@ public sealed class V2ClientConnectionOwnerTests
         }
         finally
         {
-            releaseFirstObserver.Set();
+            releaseFirstObserver.TrySetResult();
         }
         await readyObserved.Task.WaitAsync(Timeout);
 
@@ -239,7 +239,7 @@ public sealed class V2ClientConnectionOwnerTests
         Assert.True((await connecting.WaitAsync(Timeout)).IsErr(out var error));
         Assert.Equal("connection.closed", error!.Code);
         Assert.Equal(DaemonConnectionState.Closed, owner.ConnectionState);
-        await owner.DisposeAsync();
+        await owner.DisposeAsync().AsTask().WaitAsync(Timeout);
     }
 
     [Fact]
@@ -1511,7 +1511,8 @@ public sealed class V2ClientConnectionOwnerTests
         {
             if (timeout.IsCompleted)
                 throw new TimeoutException("The expected owner state was not reached.");
-            await Task.Yield();
+            // Paced, not spun: a bare Task.Yield loop monopolises a scheduler slot for the whole wait.
+            await Task.Delay(1).ConfigureAwait(false);
         }
     }
 

--- a/tests/MCServerLauncher.ProtocolTests/Helpers/OffPool.cs
+++ b/tests/MCServerLauncher.ProtocolTests/Helpers/OffPool.cs
@@ -1,0 +1,37 @@
+namespace MCServerLauncher.ProtocolTests.Helpers;
+
+/// <summary>
+/// Starts work on a dedicated thread rather than a thread-pool thread.
+/// </summary>
+/// <remarks>
+/// Tests that deliberately block — to poise a race, or to bridge a synchronous production
+/// interface — must not hold a pool thread while doing so. The code under test needs the same
+/// pool to make progress, and on a two-core runner a handful of parked workers is enough to
+/// stall every other collection until the pool injects replacements.
+/// </remarks>
+internal static class OffPool
+{
+    internal static Task Run(Action work) => Task.Factory.StartNew(
+        work,
+        CancellationToken.None,
+        TaskCreationOptions.LongRunning,
+        TaskScheduler.Default);
+
+    internal static Task<T> Run<T>(Func<T> work) => Task.Factory.StartNew(
+        work,
+        CancellationToken.None,
+        TaskCreationOptions.LongRunning,
+        TaskScheduler.Default);
+
+    internal static Task RunAsync(Func<Task> work) => Task.Factory.StartNew(
+        work,
+        CancellationToken.None,
+        TaskCreationOptions.LongRunning,
+        TaskScheduler.Default).Unwrap();
+
+    internal static Task<T> RunAsync<T>(Func<Task<T>> work) => Task.Factory.StartNew(
+        work,
+        CancellationToken.None,
+        TaskCreationOptions.LongRunning,
+        TaskScheduler.Default).Unwrap();
+}

--- a/tests/MCServerLauncher.ProtocolTests/Plugins/PluginHostLifecycleTests.cs
+++ b/tests/MCServerLauncher.ProtocolTests/Plugins/PluginHostLifecycleTests.cs
@@ -42,11 +42,8 @@ public sealed class PluginHostLifecycleTests
         // Gate for the late-success leg: the delayed plugin stays incomplete until this file
         // appears, so its success lands strictly after the host has already timed it out.
         var lateSuccessRelease = Path.Combine(Path.GetTempPath(), $"mcsl-late-success-{Guid.NewGuid():N}.release");
-        var lateSuccessCompleted = Path.Combine(Path.GetTempPath(), $"mcsl-late-success-{Guid.NewGuid():N}.completed");
         var previousRelease = Environment.GetEnvironmentVariable("MCSL_PLUGIN_LATE_SUCCESS_RELEASE_PATH");
-        var previousCompleted = Environment.GetEnvironmentVariable("MCSL_PLUGIN_LATE_SUCCESS_COMPLETED_PATH");
         Environment.SetEnvironmentVariable("MCSL_PLUGIN_LATE_SUCCESS_RELEASE_PATH", lateSuccessRelease);
-        Environment.SetEnvironmentVariable("MCSL_PLUGIN_LATE_SUCCESS_COMPLETED_PATH", lateSuccessCompleted);
         try
         {
             using var fixture = PluginHostFixture.Create(
@@ -116,10 +113,11 @@ public sealed class PluginHostLifecycleTests
                 ("fixture.start-late-success", PluginRuntimeState.Failed),
                 ("fixture.start-synchronously-blocks", PluginRuntimeState.Failed));
 
-            // Now let the timed-out plugin actually succeed. Waiting on its own completion signal
-            // replaces a fixed sleep that could not tell "late success rejected" from "never ran".
+            // Now let the timed-out plugin actually succeed. Wait on the HOST's record of that late
+            // completion, not on the plugin's own signal: the host continuation is where a
+            // regression would re-admit, so anchoring here orders the assertions after it.
             File.WriteAllText(lateSuccessRelease, string.Empty);
-            await WaitForFileAsync(lateSuccessCompleted, TimeSpan.FromSeconds(30));
+            await WaitForLogMessageAsync(logger, "start_discarded_late", TimeSpan.FromSeconds(30));
 
             AssertStates(
                 host.States,
@@ -144,11 +142,8 @@ public sealed class PluginHostLifecycleTests
         finally
         {
             Environment.SetEnvironmentVariable("MCSL_PLUGIN_LATE_SUCCESS_RELEASE_PATH", previousRelease);
-            Environment.SetEnvironmentVariable("MCSL_PLUGIN_LATE_SUCCESS_COMPLETED_PATH", previousCompleted);
             if (File.Exists(lateSuccessRelease))
                 File.Delete(lateSuccessRelease);
-            if (File.Exists(lateSuccessCompleted))
-                File.Delete(lateSuccessCompleted);
         }
     }
 

--- a/tests/MCServerLauncher.ProtocolTests/Plugins/PluginHostLifecycleTests.cs
+++ b/tests/MCServerLauncher.ProtocolTests/Plugins/PluginHostLifecycleTests.cs
@@ -64,16 +64,21 @@ public sealed class PluginHostLifecycleTests
             new PluginEventBus(provider.GetRequiredService<EventFactory>()),
             TimeSpan.FromMilliseconds(250),
             fixture.CreateConfig("Medium"),
-            new PluginHttpEndpointRegistry());
+            new PluginHttpEndpointRegistry(),
+            // None of these plugins ever finish starting, so a startup that waits on their rollback
+            // waits on this deadline. Making it far longer than the test turns "supervision is
+            // bounded" into a liveness property instead of a stopwatch comparison.
+            rollbackCleanupTimeout: TimeSpan.FromMinutes(10),
+            shutdownCleanupTimeout: TimeSpan.FromMilliseconds(150));
 
-        // Allow scheduler contention from the full protocol suite while still bounding an
-        // otherwise unbounded startup. The fixture includes permanently incomplete starts.
-        var supervisionBudget = TimeSpan.FromSeconds(8);
-        var startedAt = Stopwatch.GetTimestamp();
-        await host.StartAsync(CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(10));
-        var elapsed = Stopwatch.GetElapsedTime(startedAt);
+        // The fixture includes permanently incomplete starts, so an unsupervised startup never
+        // returns at all. A wall-clock budget could not tell that apart from a loaded runner: it
+        // failed CI at 18.6s while the WaitAsync guard below saw the task finish in time.
+        var start = host.StartAsync(CancellationToken.None);
+        var completed = await Task.WhenAny(start, Task.Delay(TimeSpan.FromSeconds(60)));
+        Assert.True(ReferenceEquals(completed, start), "Plugin supervision never bounded the startup.");
+        await start;
 
-        Assert.True(elapsed < supervisionBudget, $"Plugin supervision took {elapsed}.");
         Assert.Contains(logger.Messages, message =>
             message.Contains("fixture.start-never-completes", StringComparison.Ordinal) &&
             message.Contains("start_timed_out", StringComparison.Ordinal));
@@ -116,7 +121,7 @@ public sealed class PluginHostLifecycleTests
             ("fixture.start-ignores-cancellation", PluginRuntimeState.Failed),
             ("fixture.start-late-success", PluginRuntimeState.Failed),
             ("fixture.start-synchronously-blocks", PluginRuntimeState.Failed));
-        await host.StopAsync(CancellationToken.None);
+        await host.StopAsync(CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(60));
     }
 
     [Fact]

--- a/tests/MCServerLauncher.ProtocolTests/Plugins/PluginHostLifecycleTests.cs
+++ b/tests/MCServerLauncher.ProtocolTests/Plugins/PluginHostLifecycleTests.cs
@@ -146,21 +146,29 @@ public sealed class PluginHostLifecycleTests
                 new PluginEventBus(provider.GetRequiredService<EventFactory>()),
                 TimeSpan.FromMilliseconds(150),
                 fixture.CreateConfig("Medium"),
-                new PluginHttpEndpointRegistry());
+                new PluginHttpEndpointRegistry(),
+                // The plugin's StopAsync never completes, and StopRollbackAsync can only escape it
+                // via this deadline (the shutdown boundary does not exist until StopAsync runs).
+                // Making it far longer than the test means awaiting the rollback is indistinguishable
+                // from hanging, so "StartAsync returned" is itself the assertion.
+                rollbackCleanupTimeout: TimeSpan.FromMinutes(10),
+                // ...and the shutdown boundary is what releases that abandoned rollback, so keep it
+                // short or teardown pays the full rollback deadline.
+                shutdownCleanupTimeout: TimeSpan.FromMilliseconds(150));
 
-            var startedAt = Stopwatch.GetTimestamp();
-            await host.StartAsync(CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(2));
-            var elapsed = Stopwatch.GetElapsedTime(startedAt);
-
+            var start = host.StartAsync(CancellationToken.None);
+            var completed = await Task.WhenAny(start, Task.Delay(TimeSpan.FromSeconds(30)));
             Assert.True(
-                elapsed < TimeSpan.FromSeconds(2),
-                $"Startup waited for rollback cleanup after the 150 ms deadline: {elapsed}.");
+                ReferenceEquals(completed, start),
+                "StartAsync never returned, so it is awaiting the non-cooperative rollback.");
+            await start;
+
             AssertStates(host.States, ("fixture.start-never-completes", PluginRuntimeState.Failed));
             Assert.Contains(logger.Messages, message =>
                 message.Contains("fixture.start-never-completes", StringComparison.Ordinal) &&
                 message.Contains("start_timed_out", StringComparison.Ordinal));
 
-            await host.StopAsync(CancellationToken.None);
+            await host.StopAsync(CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(30));
         }
         finally
         {

--- a/tests/MCServerLauncher.ProtocolTests/Plugins/PluginHostLifecycleTests.cs
+++ b/tests/MCServerLauncher.ProtocolTests/Plugins/PluginHostLifecycleTests.cs
@@ -39,89 +39,117 @@ public sealed class PluginHostLifecycleTests
     [Fact]
     public async Task StartAsync_BoundsNonCooperativeStartsAndRejectsLateCompletion()
     {
-        using var fixture = PluginHostFixture.Create(
-            ("fixture.start-never-completes", typeof(NeverCompletingStartPlugin).Assembly, typeof(NeverCompletingStartPlugin).FullName!),
-            ("fixture.start-blocking-lifetime-cancellation", typeof(BlockingLifetimeCancellationPlugin).Assembly, typeof(BlockingLifetimeCancellationPlugin).FullName!),
-            ("fixture.start-blocking-start-cancellation", typeof(BlockingStartCancellationPlugin).Assembly, typeof(BlockingStartCancellationPlugin).FullName!),
-            ("fixture.start-ignores-cancellation", typeof(IgnoresCancellationStartPlugin).Assembly, typeof(IgnoresCancellationStartPlugin).FullName!),
-            ("fixture.start-late-success", typeof(DelayedRegisteredSuccessPlugin).Assembly, typeof(DelayedRegisteredSuccessPlugin).FullName!),
-            ("fixture.start-synchronously-blocks", typeof(SynchronouslyBlockingStartPlugin).Assembly, typeof(SynchronouslyBlockingStartPlugin).FullName!));
-        var logger = new RecordingLogger<PluginHost>();
-        var services = new ServiceCollection();
-        services.AddMessagePipe(options =>
+        // Gate for the late-success leg: the delayed plugin stays incomplete until this file
+        // appears, so its success lands strictly after the host has already timed it out.
+        var lateSuccessRelease = Path.Combine(Path.GetTempPath(), $"mcsl-late-success-{Guid.NewGuid():N}.release");
+        var lateSuccessCompleted = Path.Combine(Path.GetTempPath(), $"mcsl-late-success-{Guid.NewGuid():N}.completed");
+        var previousRelease = Environment.GetEnvironmentVariable("MCSL_PLUGIN_LATE_SUCCESS_RELEASE_PATH");
+        var previousCompleted = Environment.GetEnvironmentVariable("MCSL_PLUGIN_LATE_SUCCESS_COMPLETED_PATH");
+        Environment.SetEnvironmentVariable("MCSL_PLUGIN_LATE_SUCCESS_RELEASE_PATH", lateSuccessRelease);
+        Environment.SetEnvironmentVariable("MCSL_PLUGIN_LATE_SUCCESS_COMPLETED_PATH", lateSuccessCompleted);
+        try
         {
-            options.EnableAutoRegistration = false;
-            options.DefaultAsyncPublishStrategy = AsyncPublishStrategy.Sequential;
-            options.InstanceLifetime = InstanceLifetime.Singleton;
-            options.EnableCaptureStackTrace = false;
-        });
-        using var provider = services.BuildServiceProvider();
-        var host = new PluginHost(
-            new SnapshotSource(new InstanceCatalogSnapshot([])),
-            new RecordingLoggerFactory(logger),
-            logger,
-            fixture.PluginsRoot,
-            new PluginEventBus(provider.GetRequiredService<EventFactory>()),
-            TimeSpan.FromMilliseconds(250),
-            fixture.CreateConfig("Medium"),
-            new PluginHttpEndpointRegistry(),
-            // None of these plugins ever finish starting, so a startup that waits on their rollback
-            // waits on this deadline. Making it far longer than the test turns "supervision is
-            // bounded" into a liveness property instead of a stopwatch comparison.
-            rollbackCleanupTimeout: TimeSpan.FromMinutes(10),
-            shutdownCleanupTimeout: TimeSpan.FromMilliseconds(150));
+            using var fixture = PluginHostFixture.Create(
+                ("fixture.start-never-completes", typeof(NeverCompletingStartPlugin).Assembly, typeof(NeverCompletingStartPlugin).FullName!),
+                ("fixture.start-blocking-lifetime-cancellation", typeof(BlockingLifetimeCancellationPlugin).Assembly, typeof(BlockingLifetimeCancellationPlugin).FullName!),
+                ("fixture.start-blocking-start-cancellation", typeof(BlockingStartCancellationPlugin).Assembly, typeof(BlockingStartCancellationPlugin).FullName!),
+                ("fixture.start-ignores-cancellation", typeof(IgnoresCancellationStartPlugin).Assembly, typeof(IgnoresCancellationStartPlugin).FullName!),
+                ("fixture.start-late-success", typeof(DelayedRegisteredSuccessPlugin).Assembly, typeof(DelayedRegisteredSuccessPlugin).FullName!),
+                ("fixture.start-synchronously-blocks", typeof(SynchronouslyBlockingStartPlugin).Assembly, typeof(SynchronouslyBlockingStartPlugin).FullName!));
+            var logger = new RecordingLogger<PluginHost>();
+            var services = new ServiceCollection();
+            services.AddMessagePipe(options =>
+            {
+                options.EnableAutoRegistration = false;
+                options.DefaultAsyncPublishStrategy = AsyncPublishStrategy.Sequential;
+                options.InstanceLifetime = InstanceLifetime.Singleton;
+                options.EnableCaptureStackTrace = false;
+            });
+            using var provider = services.BuildServiceProvider();
+            var host = new PluginHost(
+                new SnapshotSource(new InstanceCatalogSnapshot([])),
+                new RecordingLoggerFactory(logger),
+                logger,
+                fixture.PluginsRoot,
+                new PluginEventBus(provider.GetRequiredService<EventFactory>()),
+                TimeSpan.FromMilliseconds(250),
+                fixture.CreateConfig("Medium"),
+                new PluginHttpEndpointRegistry(),
+                // None of these plugins ever finish starting, so a startup that waits on their rollback
+                // waits on this deadline. Making it far longer than the test turns "supervision is
+                // bounded" into a liveness property instead of a stopwatch comparison.
+                rollbackCleanupTimeout: TimeSpan.FromMinutes(10),
+                shutdownCleanupTimeout: TimeSpan.FromMilliseconds(150));
 
-        // The fixture includes permanently incomplete starts, so an unsupervised startup never
-        // returns at all. A wall-clock budget could not tell that apart from a loaded runner: it
-        // failed CI at 18.6s while the WaitAsync guard below saw the task finish in time.
-        var start = host.StartAsync(CancellationToken.None);
-        var completed = await Task.WhenAny(start, Task.Delay(TimeSpan.FromSeconds(60)));
-        Assert.True(ReferenceEquals(completed, start), "Plugin supervision never bounded the startup.");
-        await start;
+            // The fixture includes permanently incomplete starts, so an unsupervised startup never
+            // returns at all. A wall-clock budget could not tell that apart from a loaded runner: it
+            // failed CI at 18.6s while the WaitAsync guard below saw the task finish in time.
+            var start = host.StartAsync(CancellationToken.None);
+            var completed = await Task.WhenAny(start, Task.Delay(TimeSpan.FromSeconds(60)));
+            Assert.True(ReferenceEquals(completed, start), "Plugin supervision never bounded the startup.");
+            await start;
 
-        Assert.Contains(logger.Messages, message =>
-            message.Contains("fixture.start-never-completes", StringComparison.Ordinal) &&
-            message.Contains("start_timed_out", StringComparison.Ordinal));
-        Assert.Contains(logger.Messages, message =>
-            message.Contains("fixture.start-blocking-lifetime-cancellation", StringComparison.Ordinal) &&
-            message.Contains("start_timed_out", StringComparison.Ordinal));
-        Assert.Contains(logger.Messages, message =>
-            message.Contains("fixture.start-blocking-start-cancellation", StringComparison.Ordinal) &&
-            message.Contains("start_timed_out", StringComparison.Ordinal));
-        Assert.Contains(logger.Messages, message =>
-            message.Contains("fixture.start-ignores-cancellation", StringComparison.Ordinal) &&
-            message.Contains("start_timed_out", StringComparison.Ordinal));
-        Assert.Contains(logger.Messages, message =>
-            message.Contains("fixture.start-late-success", StringComparison.Ordinal) &&
-            message.Contains("start_timed_out", StringComparison.Ordinal));
-        Assert.Contains(logger.Messages, message =>
-            message.Contains("fixture.start-synchronously-blocks", StringComparison.Ordinal) &&
-            message.Contains("start_timed_out", StringComparison.Ordinal));
-        AssertStates(
-            host.States,
-            ("fixture.start-never-completes", PluginRuntimeState.Failed),
-            ("fixture.start-blocking-lifetime-cancellation", PluginRuntimeState.Failed),
-            ("fixture.start-blocking-start-cancellation", PluginRuntimeState.Failed),
-            ("fixture.start-ignores-cancellation", PluginRuntimeState.Failed),
-            ("fixture.start-late-success", PluginRuntimeState.Failed),
-            ("fixture.start-synchronously-blocks", PluginRuntimeState.Failed));
+            Assert.Contains(logger.Messages, message =>
+                message.Contains("fixture.start-never-completes", StringComparison.Ordinal) &&
+                message.Contains("start_timed_out", StringComparison.Ordinal));
+            Assert.Contains(logger.Messages, message =>
+                message.Contains("fixture.start-blocking-lifetime-cancellation", StringComparison.Ordinal) &&
+                message.Contains("start_timed_out", StringComparison.Ordinal));
+            Assert.Contains(logger.Messages, message =>
+                message.Contains("fixture.start-blocking-start-cancellation", StringComparison.Ordinal) &&
+                message.Contains("start_timed_out", StringComparison.Ordinal));
+            Assert.Contains(logger.Messages, message =>
+                message.Contains("fixture.start-ignores-cancellation", StringComparison.Ordinal) &&
+                message.Contains("start_timed_out", StringComparison.Ordinal));
+            Assert.Contains(logger.Messages, message =>
+                message.Contains("fixture.start-late-success", StringComparison.Ordinal) &&
+                message.Contains("start_timed_out", StringComparison.Ordinal));
+            Assert.Contains(logger.Messages, message =>
+                message.Contains("fixture.start-synchronously-blocks", StringComparison.Ordinal) &&
+                message.Contains("start_timed_out", StringComparison.Ordinal));
+            AssertStates(
+                host.States,
+                ("fixture.start-never-completes", PluginRuntimeState.Failed),
+                ("fixture.start-blocking-lifetime-cancellation", PluginRuntimeState.Failed),
+                ("fixture.start-blocking-start-cancellation", PluginRuntimeState.Failed),
+                ("fixture.start-ignores-cancellation", PluginRuntimeState.Failed),
+                ("fixture.start-late-success", PluginRuntimeState.Failed),
+                ("fixture.start-synchronously-blocks", PluginRuntimeState.Failed));
 
-        var builder = new ProtocolCatalogBuilder(new OpenRpcInfo("plugin-host-timeout-test", "1.0.0"));
-        host.AddCatalogContributions(builder);
-        var catalog = builder.Freeze();
-        Assert.Empty(catalog.Rpcs);
-        Assert.Empty(catalog.Events);
+            // Now let the timed-out plugin actually succeed. Waiting on its own completion signal
+            // replaces a fixed sleep that could not tell "late success rejected" from "never ran".
+            File.WriteAllText(lateSuccessRelease, string.Empty);
+            await WaitForFileAsync(lateSuccessCompleted, TimeSpan.FromSeconds(30));
 
-        await Task.Delay(TimeSpan.FromMilliseconds(1500));
-        AssertStates(
-            host.States,
-            ("fixture.start-never-completes", PluginRuntimeState.Failed),
-            ("fixture.start-blocking-lifetime-cancellation", PluginRuntimeState.Failed),
-            ("fixture.start-blocking-start-cancellation", PluginRuntimeState.Failed),
-            ("fixture.start-ignores-cancellation", PluginRuntimeState.Failed),
-            ("fixture.start-late-success", PluginRuntimeState.Failed),
-            ("fixture.start-synchronously-blocks", PluginRuntimeState.Failed));
-        await host.StopAsync(CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(60));
+            AssertStates(
+                host.States,
+                ("fixture.start-never-completes", PluginRuntimeState.Failed),
+                ("fixture.start-blocking-lifetime-cancellation", PluginRuntimeState.Failed),
+                ("fixture.start-blocking-start-cancellation", PluginRuntimeState.Failed),
+                ("fixture.start-ignores-cancellation", PluginRuntimeState.Failed),
+                ("fixture.start-late-success", PluginRuntimeState.Failed),
+                ("fixture.start-synchronously-blocks", PluginRuntimeState.Failed));
+
+            // The late success must not contribute the draft it registered before the deadline.
+            // Admission is single-use, so this one call covers both before and after the release:
+            // contributions only ever add, so an empty catalog here was empty earlier too.
+            var lateBuilder = new ProtocolCatalogBuilder(new OpenRpcInfo("plugin-host-timeout-test", "1.0.0"));
+            host.AddCatalogContributions(lateBuilder);
+            var lateCatalog = lateBuilder.Freeze();
+            Assert.Empty(lateCatalog.Rpcs);
+            Assert.Empty(lateCatalog.Events);
+
+            await host.StopAsync(CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(60));
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("MCSL_PLUGIN_LATE_SUCCESS_RELEASE_PATH", previousRelease);
+            Environment.SetEnvironmentVariable("MCSL_PLUGIN_LATE_SUCCESS_COMPLETED_PATH", previousCompleted);
+            if (File.Exists(lateSuccessRelease))
+                File.Delete(lateSuccessRelease);
+            if (File.Exists(lateSuccessCompleted))
+                File.Delete(lateSuccessCompleted);
+        }
     }
 
     [Fact]

--- a/tests/MCServerLauncher.ProtocolTests/Plugins/PluginHostServicesTests.cs
+++ b/tests/MCServerLauncher.ProtocolTests/Plugins/PluginHostServicesTests.cs
@@ -343,22 +343,23 @@ public sealed class PluginHostServicesTests
         var registry = new PluginHttpEndpointRegistry();
         var identity = new PluginIdentity("fixture.http.race", "1.0.0");
         var owner = new PluginHttpEndpointPolicy(identity.Id, registry, new PluginErrorFactory(identity));
-        using var start = new ManualResetEventSlim();
+        // Seventeen racers park until released; awaiting a TCS keeps them off the pool until then.
+        var start = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var registrations = Enumerable.Range(18110, 16)
-            .Select(port => Task.Run(() =>
+            .Select(async port =>
             {
-                start.Wait();
+                await start.Task;
                 return owner.ValidateAndRegister("127.0.0.1", port);
-            }))
+            })
             .ToArray();
-        var cleanup = Task.Run(() =>
+        var cleanup = Task.Run(async () =>
         {
-            start.Wait();
+            await start.Task;
             owner.ReleaseAll();
         });
 
-        start.Set();
-        await Task.WhenAll(registrations.Cast<Task>().Append(cleanup));
+        start.SetResult();
+        await Task.WhenAll(registrations.Cast<Task>().Append(cleanup)).WaitAsync(TimeSpan.FromSeconds(30));
 
         var competitorIdentity = new PluginIdentity("fixture.http.race-competitor", "1.0.0");
         var competitor = new PluginHttpEndpointPolicy(

--- a/tests/MCServerLauncher.ProtocolTests/Rpc/Events/V2EventSubscriptionLedgerTests.cs
+++ b/tests/MCServerLauncher.ProtocolTests/Rpc/Events/V2EventSubscriptionLedgerTests.cs
@@ -9,6 +9,7 @@ using MCServerLauncher.Daemon.Remote.Rpc.Catalog;
 using MCServerLauncher.Daemon.Remote.Rpc.Dispatch;
 using MCServerLauncher.Daemon.Remote.Rpc.Events;
 using MCServerLauncher.Daemon.Remote.Rpc.Transport;
+using MCServerLauncher.ProtocolTests.Helpers;
 
 namespace MCServerLauncher.ProtocolTests.Rpc.Events;
 
@@ -228,7 +229,8 @@ public sealed class V2EventSubscriptionLedgerTests
             "mcsl.event.instance.log",
             Meta("{\"instance_id\":\"11111111-1111-1111-1111-111111111111\"}"));
 
-        var subscribe = Task.Run(() => ledger.Subscribe(request));
+        // Subscribe blocks inside the synchronous canonicalizer until the test releases it.
+        var subscribe = OffPool.Run(() => ledger.Subscribe(request));
         await canonicalizer.Entered.Task.WaitAsync(TimeSpan.FromSeconds(10));
         ledger.Close();
         canonicalizer.Release.TrySetResult();

--- a/tests/MCServerLauncher.ProtocolTests/Rpc/Events/V2RemoteEventBridgeTests.cs
+++ b/tests/MCServerLauncher.ProtocolTests/Rpc/Events/V2RemoteEventBridgeTests.cs
@@ -10,6 +10,7 @@ using MCServerLauncher.Daemon.ApplicationCore.Events;
 using MCServerLauncher.Daemon.Remote.Rpc.Catalog;
 using MCServerLauncher.Daemon.Remote.Rpc.Events;
 using MCServerLauncher.Daemon.Remote.Rpc.Transport;
+using MCServerLauncher.ProtocolTests.Helpers;
 
 namespace MCServerLauncher.ProtocolTests.Rpc.Events;
 
@@ -157,19 +158,17 @@ public sealed class V2RemoteEventBridgeTests
         var clock = new BlockingTimeProvider(DateTimeOffset.FromUnixTimeMilliseconds(1_783_677_000_000));
         var bridge = new V2RemoteEventBridge(host.Port, catalog, registry, clock);
         Assert.Equal(4, host.Port.ActiveSubscriptionCount);
-        var publish = Task.Run(async () =>
+        // Publish blocks inside BlockingTimeProvider.GetUtcNow, so it needs the same off-pool
+        // treatment the racing dispose below already has.
+        var publish = OffPool.RunAsync(async () =>
             await host.Port.PublishAsync(new InstanceLogDomainEvent(Guid.NewGuid(), "race")));
         await clock.Entered.Task.WaitAsync(TimeSpan.FromSeconds(10));
         var disposeStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        var dispose = Task.Factory.StartNew(
-            () =>
-            {
-                disposeStarted.TrySetResult();
-                bridge.Dispose();
-            },
-            CancellationToken.None,
-            TaskCreationOptions.LongRunning,
-            TaskScheduler.Default);
+        var dispose = OffPool.Run(() =>
+        {
+            disposeStarted.TrySetResult();
+            bridge.Dispose();
+        });
         try
         {
             await disposeStarted.Task.WaitAsync(TimeSpan.FromSeconds(10));

--- a/tests/MCServerLauncher.ProtocolTests/Rpc/Transport/V2InboundMessagePipelineTests.cs
+++ b/tests/MCServerLauncher.ProtocolTests/Rpc/Transport/V2InboundMessagePipelineTests.cs
@@ -17,6 +17,10 @@ public sealed class V2InboundMessagePipelineTests
 {
     private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(5);
 
+    // Deliberately far larger than Timeout: this guard exists to turn a wedged pump into a named
+    // failure instead of a silent hang, not to police how long a healthy drain takes.
+    private static readonly TimeSpan DrainTimeout = TimeSpan.FromSeconds(30);
+
     [Fact]
     public async Task Text_NoResponseDoesNotEnqueue_AndPlainResponseIsSentUnchanged()
     {
@@ -34,8 +38,8 @@ public sealed class V2InboundMessagePipelineTests
         Assert.Equal(V2OutboundFrameKind.Text, sent.Kind);
         Assert.Equal(-32700, JsonRpcWireParser.ParseErrorResponse(sent.Payload.AsSpan()).Error.Code);
 
-        await fixture.Owner.CompleteAsync();
-        await pump;
+        await DrainAsync(fixture.Owner.CompleteAsync(), "The graceful connection completion");
+        await DrainAsync(pump, "The outbound pump");
     }
 
     [Theory]
@@ -64,8 +68,8 @@ public sealed class V2InboundMessagePipelineTests
         Assert.True(fixture.Application.DownloadData.AsSpan().SequenceEqual(
             binary.Payload[BinaryFrameCodec.HeaderSize..].AsSpan()));
 
-        await fixture.Owner.CompleteAsync();
-        await pump;
+        await DrainAsync(fixture.Owner.CompleteAsync(), "The graceful connection completion");
+        await DrainAsync(pump, "The outbound pump");
     }
 
     [Theory]
@@ -108,8 +112,8 @@ public sealed class V2InboundMessagePipelineTests
             Assert.Equal("mcsl.daemon", acknowledgement.Error.Data.ExecutionOwner!.Id);
         }
 
-        await fixture.Owner.AbortAsync();
-        await pump;
+        await DrainAsync(fixture.Owner.AbortAsync(), "The connection abort");
+        await DrainAsync(pump, "The outbound pump");
     }
 
     [Fact]
@@ -226,6 +230,18 @@ public sealed class V2InboundMessagePipelineTests
 
         Assert.Equal(expectedReason, fixture.Owner.CloseReason);
         Assert.Equal(expectedCause, fixture.Owner.DiagnosticStopCause);
+    }
+
+    private static async Task DrainAsync(Task work, string what)
+    {
+        try
+        {
+            await work.WaitAsync(DrainTimeout);
+        }
+        catch (TimeoutException)
+        {
+            Assert.Fail($"{what} did not finish within {DrainTimeout.TotalSeconds:0}s.");
+        }
     }
 
     private static byte[] Frame(BinaryFrameKind kind, Guid sessionId, long offset, ReadOnlySpan<byte> payload)

--- a/tests/MCServerLauncher.ProtocolTests/Rpc/Transport/V2InboundMessagePipelineTests.cs
+++ b/tests/MCServerLauncher.ProtocolTests/Rpc/Transport/V2InboundMessagePipelineTests.cs
@@ -290,7 +290,9 @@ public sealed class V2InboundMessagePipelineTests
             return new(application, sender, owner, files, pipeline);
         }
 
-        public async ValueTask DisposeAsync() => await Owner.DisposeAsync();
+        // Bounded for the same reason the pump awaits are: a wedged owner must fail here with a
+        // named timeout instead of holding the fixture until the CI blame collector kills the run.
+        public async ValueTask DisposeAsync() => await Owner.DisposeAsync().AsTask().WaitAsync(DrainTimeout);
     }
 
     private sealed class RecordingSender : IV2OutboundSender

--- a/tests/MCServerLauncher.ProtocolTests/Storage/FileSessionCoordinatorTests.cs
+++ b/tests/MCServerLauncher.ProtocolTests/Storage/FileSessionCoordinatorTests.cs
@@ -4,6 +4,7 @@ using MCServerLauncher.Common.Contracts.Files;
 using MCServerLauncher.Daemon.API.Errors;
 using MCServerLauncher.Daemon.Storage;
 using RustyOptions;
+using MCServerLauncher.ProtocolTests.Helpers;
 
 namespace MCServerLauncher.ProtocolTests;
 
@@ -739,7 +740,10 @@ public sealed class FileSessionCoordinatorTests
 
                 try
                 {
-                    secondResult.TrySetResult(Task.Run(() => coordinator!.OpenDownloadAsync(
+                    // The callback contract is synchronous, so this thread must block. Run the
+                    // nested open on a dedicated thread: waiting on a pool thread from a pool
+                    // thread deadlocks whenever the pool has no slot left to inject.
+                    secondResult.TrySetResult(OffPool.RunAsync(() => coordinator!.OpenDownloadAsync(
                         new DownloadOpenRequest(relativePath), CancellationToken.None)).GetAwaiter().GetResult());
                 }
                 catch (Exception exception)

--- a/tests/MCServerLauncher.ProtocolTests/Storage/FileSessionCoordinatorTests.cs
+++ b/tests/MCServerLauncher.ProtocolTests/Storage/FileSessionCoordinatorTests.cs
@@ -3,8 +3,8 @@ using System.Security.Cryptography;
 using MCServerLauncher.Common.Contracts.Files;
 using MCServerLauncher.Daemon.API.Errors;
 using MCServerLauncher.Daemon.Storage;
-using RustyOptions;
 using MCServerLauncher.ProtocolTests.Helpers;
+using RustyOptions;
 
 namespace MCServerLauncher.ProtocolTests;
 


### PR DESCRIPTION
## The defect

Reopened flake project (user decision, 2026-08-01) after the archived catalogue fired ~6 times in one day — a master run hanging silent for 11.5 minutes, and one PR failing 4 of 6 CI runs with a *rotating* cast of catalogued tests, including once on a docs-only delta, while 20-core and 2-core-pinned local runs stayed 100% green.

Root cause (confirmed by negative control): xunit v2 installs an assembly-wide `MaxConcurrencySyncContext(ProcessorCount)` — **2 slots on a 2-core CI runner** — and several production async types with missing `ConfigureAwait(false)` are started inline from test threads, so their entire state machines (`V2ConnectionOwner`'s pump, `EventTriggerService`'s rule loop, `InstanceProcess`'s publication chain, `V2ClientConnectionOwner`'s lifecycle worker) get pinned to those 2 slots and compete with every concurrently-running test in the assembly. The pre-fix pump demonstrably resumes on an xunit context worker; post-fix it resumes on the ThreadPool. 8 of the 9 catalogued flaky tests reduce to this one defect; the 9th is a pure hop-count-versus-starved-pool case that improves when the test-side pollutants stop holding threads.

## The fixes

- `fix(backend)` ×2 — `ConfigureAwait(false)` completed in `V2ConnectionOwner`, `EventTriggerService` (+ its supervisor chain), the `InstanceProcess` publication chain, `V2ClientConnectionOwner`'s lifecycle path, and (measurement-driven extension) `OperationCoordinator.RunOperationAsync`; the three bare `await Task.Yield()` context hops become context-free yields (`ConfigureAwaitOptions.ForceYielding`). In production there is no ambient context, so behavior is identical; the serial chains keep their order — only the resuming scheduler changes. The in-repo pattern copied is `V2ClientConnectionCoordinator`, which already did this correctly everywhere.
- `test(protocol)` — the pollutant list from the inventory: a shared `OffPool`/`DedicatedWorker` helper; intentional blocking moved off pool threads (`LongRunning`, matching existing in-repo precedent); the hot `Task.Yield` spin throttled; controlled drain scheduling via the existing `queueStateNotificationDrain` seam; previously-unguarded awaits (`await pump`, fixture disposal) bounded with named timeouts so starvation fails loudly instead of hanging the assembly. `StartHangingPlugins`' blocking cancellation callbacks are deliberately unchanged — the blocking is those fixtures' contract (and the burst is 2 callbacks ≈ 200 ms, not the 600 ms+ first estimated).
- `ci(workflow)` — `--blame-hang --blame-hang-timeout 8m --blame-hang-dump-type mini` + always-uploaded `TestResults` artifacts + a 30-minute job timeout: any future hang names its culprit test and leaves a dump instead of burning a 6-hour cancel.

## Validation, honestly stated

- Full battery green: ProtocolTests 1406/1406, ApiTests 116/116, ProtocolDocs `--check`, V1 gate, all builds 0 warnings.
- Mechanism negative control: pre-fix the outbound pump resumes on the xunit `MaxConcurrencySyncContext`; post-fix on the ThreadPool.
- Consistency probe: `maxParallelThreads=1` pinned runs are 6/6 green vs ~3/12 with default parallelism — starvation-shaped, as diagnosed.
- **Caveat:** local 2-core stress reproduces a *different* flake population than the CI catalogue (none of the 9 catalogued tests failed locally on either master or this branch across 29 runs), so local stress cannot confirm or refute the fix for the catalogued set. **CI is the experiment**: the plan is to re-run this PR's protocol-tests job repeatedly and compare against the 2026-08-01 baseline of 4 failures in 6 runs.
- Measured but deliberately deferred: the 56 three-second guard literals in `InstanceProcessEventPumpTests` are insufficient under a faithful 2-core simulation. Whether to widen them is a separate decision to make *after* the de-pinning's CI results are in (no unmeasured guard-widening, and no premature widening that would mask the structural fix's effect).

Pre-push gates per the standing process: local codex (gpt-5.6-sol, xhigh) cross-review — one finding (unbounded fixture disposal), fixed in the final commit; local battery green before push.
